### PR TITLE
Check for existence of elsi::elsi target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ specify custom installation with SCALAPACK_LIBRARIES or MKL_LIBRARIES variable")
 endif()
 
 if(ENABLE_ELSI)
-    if(NOT DEFINED ELSI_LIBRARIES)
+    if(NOT DEFINED ELSI_LIBRARIES AND NOT TARGET elsi::elsi)
         find_package(elsi 2.0 QUIET)
         if(elsi_FOUND)
             message(STATUS "ELSI CMake package found in ${elsi_DIR}")


### PR DESCRIPTION
Probably putting way too much time in trying to support ELSI in DFTB+ and its dependencies on conda-forge...

Here is a fix for an issue I noticed when building libmbd as subproject in DFTB+ when using ELSI (both with vendored dependencies and external dependencies) due to finding ELSI twice, once in DFTB+ and once in libmbd. This patch ensures ELSI is only found once.

- setting `ELSI_LIBRARIES` to `INTERFACE_LINK_LIBRARIES` from `elsi::elsi` target loses potential include directories, i.e. libmbd cannot find the module files
- prevent to find ELSI again if already found as target, i.e. in DFTB+