### PR TITLE
Fix mbd re-initializataion error

### DIFF
--- a/src/mbd_c_api.F90
+++ b/src/mbd_c_api.F90
@@ -4,7 +4,8 @@
 module mbd_c_api
 !! Implementation of C API.
 
-use iso_c_binding
+use iso_c_binding, only: c_int, c_double, c_bool, c_char, c_ptr, c_double_complex, &
+                         c_null_char, c_loc, c_f_pointer, c_associated
 use mbd_constants
 use mbd_version
 use mbd_coulomb, only: dipole_energy, coulomb_energy

--- a/src/mbd_utils.F90
+++ b/src/mbd_utils.F90
@@ -200,6 +200,9 @@ subroutine clock_init(this, n)
     class(clock_t), intent(inout) :: this
     integer, intent(in) :: n
 
+    if (allocated(this%timestamps)) deallocate (this%timestamps)
+    if (allocated(this%counts)) deallocate (this%counts)
+    if (allocated(this%levels)) deallocate (this%levels)
     allocate (this%timestamps(n), source=0_i8)
     allocate (this%counts(n), source=0_i8)
     allocate (this%levels(n), source=0)


### PR DESCRIPTION
When I tried to bring the mbd in QE up-to-date. The test of mbd+cell_relax crash at
```
At line 205 of file /home/yeluo/opt/q-e/q-e-repo/external/mbd/src/mbd_utils.F90
Fortran runtime error: Attempting to allocate already allocated variable 'this'
```

backtrace shows after relaxation mbd got reinitialized.
```
Breakpoint 1, mbd_utils::clock_init (this=..., n=100) at /home/yeluo/opt/q-e/q-e-repo/external/mbd/src/mbd_utils.F90:199
199	subroutine clock_init(this, n)
(gdb) bt
#0  mbd_utils::clock_init (this=..., n=100) at /home/yeluo/opt/q-e/q-e-repo/external/mbd/src/mbd_utils.F90:199
#1  0x0000555555d1e3d6 in mbd_geom::geom_init (this=...) at /home/yeluo/opt/q-e/q-e-repo/external/mbd/src/mbd_geom.F90:141
#2  0x0000555555d15a41 in mbd::mbd_calc_init (this=..., input=...) at /home/yeluo/opt/q-e/q-e-repo/external/mbd/src/mbd.F90:195
#3  0x00005555559091cc in libmbd_interface::init_mbd (nks_start=0, nk1=4, nk2=4, nk3=4, k1=1, k2=1, k3=1, tprnfor=.TRUE., tstress=.TRUE.)
    at /home/yeluo/opt/q-e/q-e-repo/Modules/mbdlib.f90:122
#4  0x00005555555c5436 in init_run () at /home/yeluo/opt/q-e/q-e-repo/PW/src/init_run.f90:155
#5  0x000055555565c5af in reset_gvectors () at /home/yeluo/opt/q-e/q-e-repo/PW/src/run_pwscf.f90:407
#6  0x000055555565cc12 in run_pwscf (exit_status=255) at /home/yeluo/opt/q-e/q-e-repo/PW/src/run_pwscf.f90:294
#7  0x0000555555567214 in pwscf () at /home/yeluo/opt/q-e/q-e-repo/PW/src/pwscf.f90:85
#8  0x0000555555566f3f in main (argc=<optimized out>, argv=<optimized out>) at /home/yeluo/opt/q-e/q-e-repo/PW/src/pwscf.f90:40
#9  0x00007ffff6861083 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#10 0x0000555555566f7e in _start ()
```
My solution is de-allocating before allocating.