### PR TITLE
Use the commit hash as a fallback when tag infos are missing

### DIFF
--- a/cmake/libMBDVersion.cmake
+++ b/cmake/libMBDVersion.cmake
@@ -1,6 +1,8 @@
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    find_package(Git REQUIRED)
+
     execute_process(
-        COMMAND git describe --tags --dirty=.dirty
+        COMMAND git describe --tags --dirty=.dirty --always
         OUTPUT_VARIABLE VERSION_TAG
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         ERROR_QUIET


### PR DESCRIPTION
Fixes https://github.com/libmbd/libmbd/issues/62
```
git describe
       --always
           Show uniquely abbreviated commit object as fallback.
```
