### PR TITLE
Fix version handling in case of using git hash

### DIFF
--- a/cmake/libMBDVersion.cmake
+++ b/cmake/libMBDVersion.cmake
@@ -2,11 +2,23 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
     find_package(Git REQUIRED)
 
     execute_process(
-        COMMAND git describe --tags --dirty=.dirty --always
+        COMMAND git describe --tags --dirty=.dirty
+        RESULTS_VARIABLE RUN_TAG_EXTRACTION_FAIL
         OUTPUT_VARIABLE VERSION_TAG
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # when tag based description fails, use hash
+    if(RUN_TAG_EXTRACTION_FAIL)
+        execute_process(
+            COMMAND git describe --tags --dirty=.dirty --always
+            OUTPUT_VARIABLE VERSION_TAG
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+
     message(STATUS "Setting version tag to ${VERSION_TAG} from Git")
 elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/libMBDVersionTag.cmake")
     include(libMBDVersionTag)
@@ -19,9 +31,17 @@ else()
 endif()
 
 set(PROJECT_VERSION ${VERSION_TAG})
-string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)-?(.*)?$" VERSION_TAG ${VERSION_TAG})
 
-set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
-set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
-set(PROJECT_VERSION_SUFFIX ${CMAKE_MATCH_4})
+if(RUN_TAG_EXTRACTION_FAIL)
+    set(PROJECT_VERSION_MAJOR 0)
+    set(PROJECT_VERSION_MINOR 0)
+    set(PROJECT_VERSION_PATCH 0)
+    set(PROJECT_VERSION_SUFFIX ${VERSION_TAG})
+else()
+    string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)-?(.*)?$" VERSION_TAG ${VERSION_TAG})
+
+    set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
+    set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
+    set(PROJECT_VERSION_SUFFIX ${CMAKE_MATCH_4})
+endif()


### PR DESCRIPTION
Fix an issue introduced by https://github.com/libmbd/libmbd/pull/67
Assign all version numbers to 0 and hash to the version suffix.