### PR TITLE
Option to force compilation using mpif.h instead of mpi_f08

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ include(CTest)
 option(ENABLE_SCALAPACK_MPI "Enable parallelisation with ScaLAPACK/MPI")
 CMAKE_DEPENDENT_OPTION(ENABLE_ELSI "Enable ELSI interface" OFF ENABLE_SCALAPACK_MPI OFF)
 option(ENABLE_C_API "Enable C API" ON)
+# Option to force disabling WITH_MPIF08, even if available
+option(FORCE_NO_MPIF08 "Force disabling use of mpif08 Fortran module" OFF)
 
 option(BUILD_SHARED_LIBS "Build shared rather than static library" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,7 @@ target_include_directories(mbd
 if(ENABLE_SCALAPACK_MPI)
     target_link_libraries(mbd PRIVATE MPI::MPI_Fortran scalapack)
     set_property(TARGET mbd APPEND PROPERTY COMPILE_DEFINITIONS WITH_MPI WITH_SCALAPACK)
-    if(MPI_Fortran_HAVE_F08_MODULE)
+    if(MPI_Fortran_HAVE_F08_MODULE AND NOT FORCE_NO_MPIF08)
         set_property(TARGET mbd APPEND PROPERTY COMPILE_DEFINITIONS WITH_MPIF08)
     endif()
 endif()


### PR DESCRIPTION
It looks to me like CMake is automatically detecting whether fortran has mpi_f08 support and then compiling libmbd using mpi dataypes from the mpi_f08 Fortran module. But if the calling code is using "mpif.h" then it will not have a type(MPI_comm) to pass.
I propose to add an option to force the code to be compiled without mpi_f08 types

Or maybe there is already a way to do this trough cmake?