### PR TITLE
Fix for comm /= MPI_COMM_WORLD

### DIFF
--- a/src/mbd_blacs.f90
+++ b/src/mbd_blacs.f90
@@ -87,23 +87,29 @@ end interface
 contains
 
 subroutine blacs_grid_init(this, comm)
+    use mpi
     class(blacs_grid_t), intent(inout) :: this
     integer, intent(in), optional :: comm
 
     integer :: my_task, n_tasks, nprows
+    integer :: ierr
 
-    call BLACS_PINFO(my_task, n_tasks)
+    if (present(comm)) then
+        call MPI_Comm_rank(comm, my_task, ierr)
+        call MPI_Comm_size(comm, n_tasks, ierr)
+        this%comm = comm
+        this%ctx = comm
+    else
+        call BLACS_PINFO(my_task, n_tasks)
+        this%comm = MPI_COMM_WORLD
+        call BLACS_GET(0, 0, this%ctx)
+    end if
+
     do nprows = int(sqrt(dble(n_tasks))), 1, -1
         if (mod(n_tasks, nprows) == 0) exit
     end do
     this%nprows = nprows
     this%npcols = n_tasks / this%nprows
-    if (present(comm)) then
-        this%ctx = comm
-        this%comm = comm
-    else
-        call BLACS_GET(0, 0, this%ctx)
-    end if
     call BLACS_GRIDINIT(this%ctx, 'R', this%nprows, this%npcols)
     call BLACS_GRIDINFO( &
         this%ctx, this%nprows, this%npcols, this%my_prow, this%my_pcol &


### PR DESCRIPTION
Currently the code is using `call BLACS_PINFO(my_task, n_tasks)` to determine the number tasks.
But this routine always assumes the MPI_COMM_WORLD is passed.
If a communicator different from MPI_COMM_WORLD has been passed, then the number of tasks can be different.
I think the correct number of tasks should be obtained from `call MPI_Comm_size` and correspondingly the rank from `call MPI_Comm_rank` as outlined here.

Currently if we pass a `comm` communicator that has a number of ranks different from MPI_COMM_WORLD the code will silently crash in BLACS_GRIDINIT because it will try to create a grid for the number of tasks in MPI_COMM_WORLD while a different number is present in `this%ctx`.