### PR TITLE
Add session-start hook to install test suite dependencies

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+# Install system dependencies for libMBD (Fortran compiler + LAPACK/BLAS)
+sudo apt-get install -yq --no-install-suggests --no-install-recommends \
+    gfortran libblas-dev liblapack-dev
+
+# Set up Python virtual environment
+VENV="$HOME/env"
+if [ ! -d "$VENV" ]; then
+    python3 -m venv "$VENV"
+fi
+source "$VENV/bin/activate"
+pip install -U pip --quiet
+
+# Build and install libMBD (Fortran) + pyMBD (Python bindings + test deps)
+cd "$CLAUDE_PROJECT_DIR"
+export VIRTUAL_ENV="$VENV"
+export LIBMBD_PREFIX="$VENV"
+make install_editable
+
+# Persist environment variables for the rest of the session
+echo "export VIRTUAL_ENV=$VENV" >> "$CLAUDE_ENV_FILE"
+echo "export PATH=$VENV/bin:\$PATH" >> "$CLAUDE_ENV_FILE"
+echo "export LIBMBD_PREFIX=$VENV" >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/session-start.sh` that installs all dependencies needed to build and run the test suite in remote Claude Code sessions
- Adds `.claude/settings.json` to register the hook with the Claude Code harness
- The hook installs `gfortran`, `libblas-dev`, `liblapack-dev` via apt, creates a Python venv at `$HOME/env`, builds libMBD (Fortran) via CMake, and installs pyMBD with test extras

## What the hook installs

| Dependency | Why |
|---|---|
| `gfortran` | Fortran compiler for libMBD source |
| `libblas-dev` / `liblapack-dev` | Linear algebra libraries required by libMBD |
| Python venv + pip | Isolated Python environment |
| pyMBD `[test]` extras | `scipy`, `numpy`, `cffi`, `pytest` |

## Test plan

- [x] Hook script runs to completion (`CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh`)
- [x] `pytest tests/test_main.py` passes (1 test)
- [x] `pytest tests/test_fortran.py` passes (23 tests, Fortran backend)

https://claude.ai/code/session_01FCT6bVCi5BWLMN4ifR7xAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCT6bVCi5BWLMN4ifR7xAo)_