### PR TITLE
Add Intel compiler (ifx + ifort) CI jobs using free oneAPI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -189,7 +189,7 @@ jobs:
           # setup-fortran already sourced setvars.sh (SETVARS_COMPLETED=1), so a
           # plain re-source returns exit 3; --force re-runs it and also picks up
           # the MKL component installed above.
-          source /opt/intel/oneapi/setvars.sh --force || true
+          source /opt/intel/oneapi/setvars.sh --force
           test -n "${MKLROOT:-}" || { echo "::error::MKLROOT unset after sourcing setvars.sh"; exit 1; }
           for v in MKLROOT LD_LIBRARY_PATH LIBRARY_PATH CPATH CMAKE_PREFIX_PATH PKG_CONFIG_PATH NLSPATH; do
             echo "$v=${!v}" >>"$GITHUB_ENV"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,3 +160,62 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  intel:
+    if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'
+    name: Intel (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # intel -> ifx + icx (LLVM-based), intel-classic -> ifort (last release)
+        toolchain: [intel, intel-classic]
+    env:
+      VIRTUAL_ENV: ${{ github.workspace }}/env
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Intel Fortran/C compiler
+        id: setup-fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: ${{ matrix.toolchain }}
+      - name: Install Intel MKL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq --no-install-suggests --no-install-recommends intel-oneapi-mkl-devel
+      - name: Set up oneAPI environment
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          for v in MKLROOT LD_LIBRARY_PATH LIBRARY_PATH CPATH CMAKE_PREFIX_PATH PKG_CONFIG_PATH NLSPATH; do
+            echo "$v=${!v}" >>"$GITHUB_ENV"
+          done
+      - name: Create Python virtual environment
+        run: |
+          python3 -m venv "$VIRTUAL_ENV"
+          "$VIRTUAL_ENV/bin/pip" install -U pip
+          echo "$VIRTUAL_ENV/bin" >>"$GITHUB_PATH"
+      - name: Set CMAKE_ARGS
+        run: |
+          FC="${{ steps.setup-fortran.outputs.fc }}"
+          CC="${{ steps.setup-fortran.outputs.cc }}"
+          echo "CMAKE_ARGS=-DCMAKE_Fortran_COMPILER=$FC -DCMAKE_C_COMPILER=${CC:-gcc} -DBLA_VENDOR=Intel10_64lp_seq" >>"$GITHUB_ENV"
+      - name: Report environment
+        run: |
+          "${{ steps.setup-fortran.outputs.fc }}" --version
+          cmake --version
+          echo "MKLROOT=$MKLROOT"
+          git describe --tags --dirty=.dirty
+      - name: Build libMBD
+        run: make build_libmbd
+      - name: Install libMBD
+        run: make install_libmbd -o build_libmbd
+      - name: Build & install pyMBD
+        run: make install -o install_libmbd
+      - run: pip list
+      - name: Test libMBD
+        run: make test_libmbd
+      - name: Test pyMBD
+        run: |
+          make test -o test_libmbd | tee output
+          ! grep failed output >/dev/null

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -186,7 +186,11 @@ jobs:
           sudo apt-get install -yq --no-install-suggests --no-install-recommends intel-oneapi-mkl-devel
       - name: Set up oneAPI environment
         run: |
-          source /opt/intel/oneapi/setvars.sh
+          # setup-fortran already sourced setvars.sh (SETVARS_COMPLETED=1), so a
+          # plain re-source returns exit 3; --force re-runs it and also picks up
+          # the MKL component installed above.
+          source /opt/intel/oneapi/setvars.sh --force || true
+          test -n "${MKLROOT:-}" || { echo "::error::MKLROOT unset after sourcing setvars.sh"; exit 1; }
           for v in MKLROOT LD_LIBRARY_PATH LIBRARY_PATH CPATH CMAKE_PREFIX_PATH PKG_CONFIG_PATH NLSPATH; do
             echo "$v=${!v}" >>"$GITHUB_ENV"
           done

--- a/cmake/fortran_flags_override.cmake
+++ b/cmake/fortran_flags_override.cmake
@@ -3,4 +3,9 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         "-fall-intrinsics -std=f2008ts -pedantic -Wall -Wcharacter-truncation -Wimplicit-procedure -Wextra -Wno-maybe-uninitialized")
     set(CMAKE_Fortran_FLAGS_DEBUG_INIT
         "-Og -fcheck=all -fno-check-array-temporaries")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
+    # Covers both ifort ("Intel") and ifx ("IntelLLVM")
+    set(CMAKE_Fortran_FLAGS_INIT "-warn all")
+    set(CMAKE_Fortran_FLAGS_DEBUG_INIT
+        "-g -traceback -check all,noarg_temp_created")
 endif()

--- a/cmake/fortran_flags_override.cmake
+++ b/cmake/fortran_flags_override.cmake
@@ -7,5 +7,5 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
     # Covers both ifort ("Intel") and ifx ("IntelLLVM")
     set(CMAKE_Fortran_FLAGS_INIT "-warn all")
     set(CMAKE_Fortran_FLAGS_DEBUG_INIT
-        "-g -traceback -check all,noarg_temp_created")
+        "-O0 -g -traceback -check all,noarg_temp_created")
 endif()


### PR DESCRIPTION
## Summary

Adds CI coverage with the free Intel oneAPI compilers so we catch Intel-specific build failures and bugs (like the seg-fault workaround already in `src/mbd_dipole.F90:402`) before they reach users.

- New `intel` matrix job in the **Tests** workflow, run via [`fortran-lang/setup-fortran`](https://github.com/fortran-lang/setup-fortran):
  - `intel` toolchain → **ifx** (modern, LLVM-based) + icx
  - `intel-classic` toolchain → **ifort** (classic, last release) 
- BLAS/LAPACK provided by free **Intel MKL** (`intel-oneapi-mkl-devel`) via CMake's `BLA_VENDOR=Intel10_64lp_seq`.
- Intel branch added to `cmake/fortran_flags_override.cmake`: `-warn all` plus Debug-mode `-check all,noarg_temp_created -traceback`, mirroring the diagnostic intent of the existing GNU flags.

Serial build only (no MPI/ScaLAPACK/ELSI) to keep the matrix focused on the compiler variable.

## Notes / things that may need a CI-driven tweak

I can't run the Intel toolchain in the dev sandbox, so the Intel job itself is validated by the first CI run. Likely tuning points:

- **MKL discovery**: relies on `MKLROOT`/`LD_LIBRARY_PATH` from `setvars.sh` + CMake's `FindLAPACK`. If `BLA_VENDOR` doesn't locate MKL on the runner's MKL layout, we may switch to MKL's own CMake config.
- **`-check all` on ifx**: runtime checks may surface latent issues or false positives (esp. ifx `-check uninit`). If noisy, dial back to `-check bounds,pointers,stack`. A red run here is informative — it's the whole point.
- **`intel-classic` C compiler**: uses `setup-fortran`'s `cc` output, falling back to `gcc` if unset (icc was dropped from recent oneAPI).

The gfortran build was verified locally to be unaffected by the flags change.

## Test plan

- [ ] `intel` (ifx) job: configure, build libMBD, ctest, build pyMBD, pytest all green
- [ ] `intel-classic` (ifort) job: same
- [ ] Existing gfortran/macOS/conda jobs still pass

https://claude.ai/code/session_01NKKH4ZoYYeqekMisLiKNPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKH4ZoYYeqekMisLiKNPF)_