### PR TITLE
Replace flake8/black/isort/pydocstyle with ruff

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
-  flake8:
+  ruff:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'
     steps:
@@ -18,41 +18,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install flake8 flake8-bugbear flake8-comprehensions flake8-quotes pep8-naming
-      - run: flake8
-  black:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install black
-      - run: black . --check
-  isort:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install isort
-      - run: isort . --check
-  pydocstyle:
-    runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: pip install pydocstyle
-      - run: pydocstyle src
+        run: pip install ruff
+      - run: ruff check
+      - run: ruff format --check
   fprettify:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository == 'libmbd/libmbd'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![commits since](https://img.shields.io/github/commits-since/libmbd/libmbd/latest.svg)](https://github.com/libmbd/libmbd/releases)
 [![last commit](https://img.shields.io/github/last-commit/libmbd/libmbd.svg)](https://github.com/libmbd/libmbd/commits/master)
 [![license](https://img.shields.io/github/license/libmbd/libmbd.svg)](https://github.com/libmbd/libmbd/blob/master/LICENSE)
-[![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
+[![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![chat](https://img.shields.io/gitter/room/libmbd/community)](https://gitter.im/libmbd/community)
 [![doi](https://img.shields.io/badge/doi-10%2Fk4bm-blue)](http://doi.org/k4bm)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,7 @@ mpi = ["mpi4py"]
 test = ["pytest"]
 
 [tool.poetry.dev-dependencies]
-flake8 = "^4"
-flake8-bugbear = "^21"
-flake8-comprehensions = "^3"
-flake8-quotes = "^3"
-pep8-naming = "^0.12"
-black = ">=22"
-pydocstyle = "^5"
-isort = "^5"
+ruff = ">=0.10"
 fprettify = { git = "https://github.com/jhrmnn/fprettify.git", rev = "fix-config-search" }
 
 [tool.poetry-dynamic-versioning]
@@ -59,6 +52,58 @@ enable = true
 dirty = true
 pattern = '^(?P<base>\d+\.\d+\.\d+)$'
 
-[tool.black]
-target-version = ["py310"]
-skip-string-normalization = true
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "N", "B", "C4", "C90", "Q", "I", "D"]
+ignore = [
+    "E501",
+    "E741",
+    "N802",
+    "N803",
+    "N806",
+    "N812",
+    "B905",
+    "D100",
+    "D104",
+    "D105",
+    "D107",
+    "D202",
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+multiline-quotes = "double"
+docstring-quotes = "double"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+no-lines-before = ["typing"]
+section-order = [
+    "future",
+    "standard-library",
+    "typing",
+    "third-party",
+    "first-party",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+typing = ["typing", "typing_extensions"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D"]
+"devtools/**" = ["D"]
+"doc/**" = ["D"]
+"build.py" = ["D"]
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,3 @@
-[flake8]
-max-complexity = 12
-max-line-length = 80
-ignore = E501,W503,E741,N802,N803,N806,N812,B905,B042
-select = C,E,F,N,W,B,B9,Q0
-
-[isort]
-multi_line_output = 3
-include_trailing_comma = 1
-line_length = 85
-sections = FUTURE,STDLIB,TYPING,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_typing = typing, typing_extensions
-no_lines_before = TYPING
-combine_as_imports = true
-
-[pydocstyle]
-add-ignore = D100,D104,D105,D107,D202
-ignore-decorators = wraps
-
 [tool:pytest]
 norecursedirs = tests/pymbd_testutils
 filterwarnings =

--- a/src/pymbd/fortran.py
+++ b/src/pymbd/fortran.py
@@ -312,9 +312,9 @@ class MBDGeom(object):
         return ene
 
     @_auto_context
-    def dipole_matrix(
+    def dipole_matrix(  # noqa: D102
         self, damping, beta=0.0, k_point=None, R_vdw=None, sigma=None, a=6.0
-    ):  # noqa: D102
+    ):
         R_vdw, sigma, k_point = map(_array, (R_vdw, sigma, k_point))
         n_atoms = len(self)
         damping_f = _lib.cmbd_init_damping(


### PR DESCRIPTION
## Summary

Consolidates the Python linting/formatting toolchain into a single tool, **ruff**. The following all fold into one dependency and one config block in `pyproject.toml`:

| Replaced | Ruff equivalent |
|---|---|
| flake8 (+ bugbear, comprehensions, quotes, pep8-naming) | `E`, `W`, `F`, `B`, `C4`, `C90`, `Q`, `N` rules |
| isort | `I` rules + `lint.isort` (custom `typing` section preserved) |
| black | `ruff format` (`quote-style = "preserve"` mirrors `skip-string-normalization`) |
| pydocstyle | `D` rules (`convention = "pep257"`, src-only via per-file-ignores) |

**fprettify** stays — it formats the Fortran sources, which ruff doesn't touch.

The four Python lint CI jobs collapse into a single `ruff` job (`ruff check` + `ruff format --check`). The config mirrors the previous rule selection, ignore list, complexity limit (12), custom isort sections, quote style, and pydocstyle convention, so **no source reformatting was required** (`ruff format` reports zero diff).

### Notes
- `W503` and `B042` from the old flake8 ignore list were dropped — neither exists in ruff (`W503` is obsolete, handled by the formatter).
- pydocstyle's `ignore-decorators = wraps` has no ruff equivalent, but it's moot here: the only `@wraps`-decorated function is nested inside a private helper, which ruff doesn't flag.
- One `# noqa: D102` was moved onto the `def` line (ruff anchors the diagnostic there for multi-line signatures, unlike pydocstyle).
- The `code style: black` README badge is now a ruff badge.

## Test plan
- [x] `ruff check` passes
- [x] `ruff format --check` reports all files already formatted (no churn)
- [x] `pyproject.toml` and `setup.cfg` parse; pytest config still resolved
- [ ] CI `ruff` and `fprettify` lint jobs pass

https://claude.ai/code/session_01VrH4Br3GoYXF7mQ5aAQbwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrH4Br3GoYXF7mQ5aAQbwM)_