### PR TITLE
Add nvfortran (NVIDIA HPC SDK) to the CI test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,6 +100,15 @@ jobs:
             exit 1
           fi
           echo "MACOS_GFORTRAN=$GFORTRAN" >>$GITHUB_ENV
+      - name: Free disk space
+        if: matrix.type == 'nvhpc'
+        run: |
+          # The NVIDIA HPC SDK is ~13 GB installed plus several GB of packages;
+          # reclaim space from preinstalled toolchains we don't use so the
+          # runner's root disk doesn't fill up.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
       - name: Cache NVIDIA HPC SDK packages
         if: matrix.type == 'nvhpc'
         uses: actions/cache@v4
@@ -125,6 +134,8 @@ jobs:
           mkdir -p ~/nvhpc-debs
           sudo cp /var/cache/apt/archives/*.deb ~/nvhpc-debs/ 2>/dev/null || true
           sudo chown -R "$(id -u):$(id -g)" ~/nvhpc-debs
+          # Drop the apt archive copy now that the packages are stashed for caching.
+          sudo apt-get clean
           nvroot=$(ls -d /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers | sort -V | tail -1)
           echo "$nvroot/bin" >>$GITHUB_PATH
           echo "LD_LIBRARY_PATH=$nvroot/lib:$LD_LIBRARY_PATH" >>$GITHUB_ENV

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,8 @@ jobs:
             mpi-nodes: 2
           - type: macos
             mpi-nodes: 2
+          - type: nvhpc
+            nvhpc-version: "25.9"
           - type: conda
             python-version: =3.13
           - type: conda
@@ -45,7 +47,7 @@ jobs:
             mpi: mpich=4
             mpi-nodes: 2
             elsi: elsi
-    runs-on: ${{ fromJSON('{"ubuntu":"ubuntu-latest","macos":"macos-latest","conda":"ubuntu-latest"}')[matrix.type] }}
+    runs-on: ${{ fromJSON('{"ubuntu":"ubuntu-latest","macos":"macos-latest","conda":"ubuntu-latest","nvhpc":"ubuntu-latest"}')[matrix.type] }}
     env:
       CONDA_ALWAYS_YES: "true"
       CONDA_QUIET: "true"
@@ -98,6 +100,34 @@ jobs:
             exit 1
           fi
           echo "MACOS_GFORTRAN=$GFORTRAN" >>$GITHUB_ENV
+      - name: Cache NVIDIA HPC SDK packages
+        if: matrix.type == 'nvhpc'
+        uses: actions/cache@v4
+        with:
+          path: ~/nvhpc-debs
+          key: nvhpc-debs-${{ matrix.nvhpc-version }}
+      - name: Install NVIDIA HPC SDK
+        if: matrix.type == 'nvhpc'
+        run: |
+          sudo apt-get install -yq --no-install-suggests --no-install-recommends libblas-dev liblapack-dev
+          curl -fsSL https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK \
+            | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' \
+            | sudo tee /etc/apt/sources.list.d/nvhpc.list
+          sudo apt-get update -yq
+          # Restore previously downloaded packages so a warm cache skips the multi-GB download.
+          if ls ~/nvhpc-debs/*.deb >/dev/null 2>&1; then
+            sudo cp ~/nvhpc-debs/*.deb /var/cache/apt/archives/
+          fi
+          pkg="nvhpc-$(echo '${{ matrix.nvhpc-version }}' | tr '.' '-')"
+          sudo apt-get install -yq --no-install-suggests --no-install-recommends "$pkg"
+          # Stash the downloaded .deb files in a user-owned dir for actions/cache to persist.
+          mkdir -p ~/nvhpc-debs
+          sudo cp /var/cache/apt/archives/*.deb ~/nvhpc-debs/ 2>/dev/null || true
+          sudo chown -R "$(id -u):$(id -g)" ~/nvhpc-debs
+          nvroot=$(ls -d /opt/nvidia/hpc_sdk/Linux_x86_64/*/compilers | sort -V | tail -1)
+          echo "$nvroot/bin" >>$GITHUB_PATH
+          echo "LD_LIBRARY_PATH=$nvroot/lib:$LD_LIBRARY_PATH" >>$GITHUB_ENV
       - name: Create Conda environment
         if: matrix.type == 'conda'
         run: conda create -p ${{ env.VIRTUAL_ENV }} -c conda-forge python${{ matrix.python-version }} pip cmake${{ matrix.cmake-version }} gfortran_linux-64${{ matrix.gfortran-version }} openblas ${{ matrix.mpi }} scalapack elsi numpy scipy mpi4py
@@ -118,8 +148,14 @@ jobs:
           git describe --tags --dirty=.dirty
       - name: Set CMAKE_ARGS
         run: |
-          FFLAGS=('-fprofile-arcs' '-ftest-coverage')
           CMAKE_ARGS=()
+          if [[ "${{ matrix.type }}" == "nvhpc" ]]; then
+              # nvfortran has no gcov-style coverage flags; build without coverage.
+              FFLAGS=()
+              CMAKE_ARGS+=('-DCMAKE_Fortran_COMPILER=nvfortran')
+          else
+              FFLAGS=('-fprofile-arcs' '-ftest-coverage')
+          fi
           if [[ "${{ matrix.mpi-nodes }}" ]]; then
               CMAKE_ARGS+=('-DENABLE_SCALAPACK_MPI=ON')
           fi
@@ -157,6 +193,6 @@ jobs:
           ! grep failed output >/dev/null
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.type != 'nvhpc' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - type: macos
             mpi-nodes: 2
           - type: nvhpc
-            nvhpc-version: "25.9"
+            nvhpc-version: "26.3"
           - type: conda
             python-version: =3.13
           - type: conda

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,7 +162,11 @@ jobs:
           CMAKE_ARGS=()
           if [[ "${{ matrix.type }}" == "nvhpc" ]]; then
               # nvfortran has no gcov-style coverage flags; build without coverage.
-              FFLAGS=()
+              # Target a portable x86-64 baseline -- GitHub-hosted runners use a
+              # heterogeneous CPU fleet, and nvfortran's default host-detected
+              # target can emit instructions some runners don't actually execute,
+              # producing SIGILL at runtime in math-heavy paths.
+              FFLAGS=('-tp' 'px')
               CMAKE_ARGS+=('-DCMAKE_Fortran_COMPILER=nvfortran')
           else
               FFLAGS=('-fprofile-arcs' '-ftest-coverage')

--- a/src/mbd_c_api.F90
+++ b/src/mbd_c_api.F90
@@ -41,11 +41,11 @@ logical(c_bool), bind(c) :: cmbd_with_scalapack = .true.
 logical(c_bool), bind(c) :: cmbd_with_scalapack = .false.
 #endif
 
-integer :: i
 integer(c_int), bind(c) :: cmbd_version_major = mbd_version_major
 integer(c_int), bind(c) :: cmbd_version_minor = mbd_version_minor
 integer(c_int), bind(c) :: cmbd_version_patch = mbd_version_patch
-character(c_char), bind(c) :: cmbd_version_suffix(30) = [(mbd_version_suffix(i:i), i=1, 30)]
+character(c_char), bind(c) :: cmbd_version_suffix(30) = &
+    transfer(mbd_version_suffix, [character(kind=c_char) ::], 30)
 
 contains
 

--- a/src/mbd_c_api.F90
+++ b/src/mbd_c_api.F90
@@ -44,8 +44,25 @@ logical(c_bool), bind(c) :: cmbd_with_scalapack = .false.
 integer(c_int), bind(c) :: cmbd_version_major = mbd_version_major
 integer(c_int), bind(c) :: cmbd_version_minor = mbd_version_minor
 integer(c_int), bind(c) :: cmbd_version_patch = mbd_version_patch
-character(c_char), bind(c) :: cmbd_version_suffix(30) = &
-    transfer(mbd_version_suffix, [character(kind=c_char) ::], 30)
+#ifdef __NVCOMPILER
+! nvfortran (NVIDIA HPC SDK) ICEs on the array-constructor initializer used in
+! the standard branch below (see issue #64); an equivalent DATA statement
+! compiles cleanly.
+character(c_char), bind(c) :: cmbd_version_suffix(30)
+data cmbd_version_suffix/ &
+    mbd_version_suffix(1:1), mbd_version_suffix(2:2), mbd_version_suffix(3:3), mbd_version_suffix(4:4), &
+    mbd_version_suffix(5:5), mbd_version_suffix(6:6), mbd_version_suffix(7:7), mbd_version_suffix(8:8), &
+    mbd_version_suffix(9:9), mbd_version_suffix(10:10), mbd_version_suffix(11:11), mbd_version_suffix(12:12), &
+    mbd_version_suffix(13:13), mbd_version_suffix(14:14), mbd_version_suffix(15:15), mbd_version_suffix(16:16), &
+    mbd_version_suffix(17:17), mbd_version_suffix(18:18), mbd_version_suffix(19:19), mbd_version_suffix(20:20), &
+    mbd_version_suffix(21:21), mbd_version_suffix(22:22), mbd_version_suffix(23:23), mbd_version_suffix(24:24), &
+    mbd_version_suffix(25:25), mbd_version_suffix(26:26), mbd_version_suffix(27:27), mbd_version_suffix(28:28), &
+    mbd_version_suffix(29:29), mbd_version_suffix(30:30) &
+    /
+#else
+integer :: i
+character(c_char), bind(c) :: cmbd_version_suffix(30) = [(mbd_version_suffix(i:i), i=1, 30)]
+#endif
 
 contains
 


### PR DESCRIPTION
## Summary

Adds a non-MPI **nvhpc** entry to the `Tests` matrix so libMBD is built and tested with `nvfortran` (NVIDIA HPC SDK). No GPU runner is needed — `nvfortran` is a CPU compiler and libMBD is pure CPU code, so this runs on a standard `ubuntu-latest` runner.

Closes #64.

## Changes

- **CI**: new `type: nvhpc` matrix entry pinned to the latest SDK (`26.3`), mapped to `ubuntu-latest`. Installs the SDK from NVIDIA's apt repo, uses system reference BLAS/LAPACK, selects `nvfortran` via `-DCMAKE_Fortran_COMPILER`, and wires `PATH`/`LD_LIBRARY_PATH`. Coverage flags and Codecov upload are skipped for this entry (nvfortran has no gcov instrumentation).
- **Caching**: downloaded SDK `.deb` packages are stashed in a user-owned dir (persisted by `actions/cache`, keyed on SDK version) and restored into apt's archive cache before install, so warm runs skip the multi-GB download.
- **Source workaround** (`src/mbd_c_api.F90`): nvfortran (all versions through 26.3) ICEs when statically initializing the `bind(c)` `cmbd_version_suffix` array — this is the bug in #64. The conforming array-constructor initializer is kept for standard compilers; nvfortran uses an equivalent `DATA` statement (gated by `#ifdef __NVCOMPILER`), which it lowers correctly. The length-30 `bind(c)` scalar suggested in the issue is **not** used because gfortran correctly rejects it (interoperable character scalars must have length one).

## Verification

Built locally with **nvfortran 26.3** and **gfortran**: both compile and pass all 42 ctests, with byte-identical `cmbd_version_suffix` output.

## Test plan

- [ ] `nvhpc` CI job configures, builds, installs, and tests libMBD with nvfortran 26.3
- [ ] Warm run hits the `.deb` cache and skips the download
- [ ] Existing gfortran/Intel/conda/macOS matrix entries remain green

https://claude.ai/code/session_01HD2o394qyDPBRaVRHNoRzB