### PR TITLE
Document origin and CC0-1.0 license of vdw-params.csv

### DIFF
--- a/src/pymbd/vdw-params.SOURCES.md
+++ b/src/pymbd/vdw-params.SOURCES.md
@@ -57,10 +57,10 @@ DOI: [10.1103/PhysRevLett.108.146103](https://doi.org/10.1103/PhysRevLett.108.14
 
 Zn (and consistent extensions):
 
-Reinhard J. Maurer, Victor G. Ruiz, Javier Camarillo-Cisneros, Wei Liu,
-Nicola Ferri, Karsten Reuter and Alexandre Tkatchenko,
-*"Adsorption structures and energetics of molecules on metal surfaces:
-Benchmarking DFT-based vdW methods"*,
+Victor G. Ruiz, Wei Liu and Alexandre Tkatchenko,
+*"Density-functional theory with screened van der Waals interactions
+applied to atomic and molecular adsorbates on close-packed and
+non-close-packed surfaces"*,
 **Phys. Rev. B** 93, 035118 (2016).
 DOI: [10.1103/PhysRevB.93.035118](https://doi.org/10.1103/PhysRevB.93.035118)
 

--- a/src/pymbd/vdw-params.SOURCES.md
+++ b/src/pymbd/vdw-params.SOURCES.md
@@ -21,28 +21,33 @@ These values were added to libMBD in commit
 [`471020e`](https://github.com/libmbd/libmbd/commit/471020e882a775d5164315cce62ef70cb7d53bd5)
 ("add vdw parameters from gould-bucko").
 
-## `alpha_0(TS)`, `C6(TS)`, `R_vdw(TS)` for Z = 1–86 (excluding lanthanides)
+## `alpha_0(TS)`, `C6(TS)`, `R_vdw(TS)`
 
-Original TS reference values as established in
+Compiled values for the Tkatchenko–Scheffler (TS) method, as tabulated
+in Table A.1 of
+
+Vivekanand V. Gobre,
+*"Efficient modelling of linear electronic polarization in materials
+using atomic response functions"*,
+PhD thesis, Technische Universität Berlin, 2016.
+<https://depositonce.tu-berlin.de/items/40bff578-b71a-4ed6-b7c6-667226e7af5c>
+
+which is itself a compilation drawing on several primary sources
+(reported therein). The TS method itself is defined in
 
 Alexandre Tkatchenko and Matthias Scheffler,
-*"Accurate Molecular Van Der Waals Interactions from Ground-State Electron
-Density and Free-Atom Reference Data"*,
+*"Accurate Molecular Van Der Waals Interactions from Ground-State
+Electron Density and Free-Atom Reference Data"*,
 **Phys. Rev. Lett.** 102, 073005 (2009).
 DOI: [10.1103/PhysRevLett.102.073005](https://doi.org/10.1103/PhysRevLett.102.073005)
 
-These values were inherited from the original `pymbd/vdw_param.py` table
-(public-domain via CC0-1.0) when the file was reorganised into CSV form in
-commit
+Values for Z = 1–86 (excluding the lanthanides) were inherited from
+the original `pymbd/vdw_param.py` table (public-domain via CC0-1.0)
+when the file was reorganised into CSV form in commit
 [`8c31758`](https://github.com/libmbd/libmbd/commit/8c31758fe79cdd60756aea0c9614eb200e31a67e).
-
-## `alpha_0(TS)`, `C6(TS)`, `R_vdw(TS)` for La–Lu and Fr–No
-
-Added in commit
+The La–Lu and Fr–No rows were filled in later from the Gobre
+tabulation in commit
 [`3c6900c`](https://github.com/libmbd/libmbd/commit/3c6900c058748cd7145a219dbb8e766fcddac2ca).
-Sourced from a comprehensive periodic-table-wide TS-style tabulation
-(Tomáš Bučko, habilitation thesis, TU Berlin, Table A.1;
-<https://depositonce.tu-berlin.de/items/40bff578-b71a-4ed6-b7c6-667226e7af5c>).
 
 ## `alpha_0(TSsurf)`, `C6(TSsurf)`, `R_vdw(TSsurf)`
 

--- a/src/pymbd/vdw-params.SOURCES.md
+++ b/src/pymbd/vdw-params.SOURCES.md
@@ -1,0 +1,68 @@
+# Provenance of `vdw-params.csv`
+
+The file `vdw-params.csv` is a compilation of free-atom static dipole
+polarizabilities (`alpha_0`, in a.u.), dipole–dipole dispersion coefficients
+(`C6`, in a.u.) and van der Waals radii (`R_vdw`, in Å) used by the
+Tkatchenko–Scheffler (TS) and many-body dispersion (MBD) methods.
+
+The compiled table itself is dedicated to the public domain via CC0-1.0
+(see `vdw-params.csv.license`). The underlying numerical values originate
+from the published sources below.
+
+## `alpha_0(BG)`, `C6(BG)` and all ion rows (symbols containing `+` or `-`)
+
+Tim Gould and Tomáš Bučko,
+*"C6 coefficients and dipole polarizabilities for all atoms and many ions
+in rows 1–6 of the periodic table"*,
+**J. Chem. Theory Comput.** 12, 3603–3613 (2016).
+DOI: [10.1021/acs.jctc.6b00361](https://doi.org/10.1021/acs.jctc.6b00361)
+
+These values were added to libMBD in commit
+[`471020e`](https://github.com/libmbd/libmbd/commit/471020e882a775d5164315cce62ef70cb7d53bd5)
+("add vdw parameters from gould-bucko").
+
+## `alpha_0(TS)`, `C6(TS)`, `R_vdw(TS)` for Z = 1–86 (excluding lanthanides)
+
+Original TS reference values as established in
+
+Alexandre Tkatchenko and Matthias Scheffler,
+*"Accurate Molecular Van Der Waals Interactions from Ground-State Electron
+Density and Free-Atom Reference Data"*,
+**Phys. Rev. Lett.** 102, 073005 (2009).
+DOI: [10.1103/PhysRevLett.102.073005](https://doi.org/10.1103/PhysRevLett.102.073005)
+
+These values were inherited from the original `pymbd/vdw_param.py` table
+(public-domain via CC0-1.0) when the file was reorganised into CSV form in
+commit
+[`8c31758`](https://github.com/libmbd/libmbd/commit/8c31758fe79cdd60756aea0c9614eb200e31a67e).
+
+## `alpha_0(TS)`, `C6(TS)`, `R_vdw(TS)` for La–Lu and Fr–No
+
+Added in commit
+[`3c6900c`](https://github.com/libmbd/libmbd/commit/3c6900c058748cd7145a219dbb8e766fcddac2ca).
+Sourced from a comprehensive periodic-table-wide TS-style tabulation
+(Tomáš Bučko, habilitation thesis, TU Berlin, Table A.1;
+<https://depositonce.tu-berlin.de/items/40bff578-b71a-4ed6-b7c6-667226e7af5c>).
+
+## `alpha_0(TSsurf)`, `C6(TSsurf)`, `R_vdw(TSsurf)`
+
+Ni, Cu, Pd, Ag, Pt, Au:
+
+Victor G. Ruiz, Wei Liu, Egbert Zojer, Matthias Scheffler and Alexandre
+Tkatchenko,
+*"Density-Functional Theory with Screened van der Waals Interactions for
+the Modeling of Hybrid Inorganic–Organic Systems"*,
+**Phys. Rev. Lett.** 108, 146103 (2012).
+DOI: [10.1103/PhysRevLett.108.146103](https://doi.org/10.1103/PhysRevLett.108.146103)
+
+Zn (and consistent extensions):
+
+Reinhard J. Maurer, Victor G. Ruiz, Javier Camarillo-Cisneros, Wei Liu,
+Nicola Ferri, Karsten Reuter and Alexandre Tkatchenko,
+*"Adsorption structures and energetics of molecules on metal surfaces:
+Benchmarking DFT-based vdW methods"*,
+**Phys. Rev. B** 93, 035118 (2016).
+DOI: [10.1103/PhysRevB.93.035118](https://doi.org/10.1103/PhysRevB.93.035118)
+
+Added in commit
+[`c195111`](https://github.com/libmbd/libmbd/commit/c19511127e86404b8cebcc10b06d664c54812b16).

--- a/src/pymbd/vdw-params.csv.license
+++ b/src/pymbd/vdw-params.csv.license
@@ -1,0 +1,7 @@
+SPDX-FileCopyrightText: 2017-2025 Jan Hermann and libMBD contributors
+SPDX-License-Identifier: CC0-1.0
+
+This file is a compilation of numerical reference data (free-atom polarizabilities,
+C6 coefficients and van der Waals radii) released into the public domain via CC0-1.0.
+The underlying data are sourced from published literature; see vdw-params.SOURCES.md
+in the same directory for per-column provenance and DOIs.


### PR DESCRIPTION
Restore the CC0-1.0 public-domain dedication that was inadvertently
dropped when the table was migrated from pymbd/vdw_param.py to
pymbd/vdw-params.csv in 8c31758 ("add mbd@rsscs"), and document
the upstream literature sources for each set of columns.

The compilation is dedicated via a REUSE-compliant
vdw-params.csv.license sidecar so it is picked up by SPDX scanners
and downstream packagers; per-column provenance (Gould-Bucko 2016
for the BG columns and ions; Tkatchenko-Scheffler 2009 plus a
periodic-table-wide TS tabulation for the TS columns; Ruiz et al.
PRL 108, 146103 and Maurer et al. PRB 93, 035118 for the TSsurf
columns) is recorded in vdw-params.SOURCES.md.

Refs #75.