### PR TITLE
Drop pkg_resources/setuptools runtime dependency (prerequisite for #96)

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -34,7 +34,7 @@ jobs:
             PIP_PKGS=pymbd
             RUN_PREFIX=
           else
-            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' mpi4py"
+            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' 'mpi4py<4'"
             PIP_PKGS="pymbd[mpi]"
             RUN_PREFIX="mpiexec -n 2"
           fi
@@ -58,7 +58,7 @@ jobs:
           echo "CONDA=/opt/homebrew/Caskroom/miniforge/base" >>$GITHUB_ENV
       - name: Create Conda environment
         run: |
-          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge python pip ${{ env.CONDA_PKGS }} numpy scipy
+          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge "python<3.12" pip "setuptools<81" ${{ env.CONDA_PKGS }} numpy scipy
           echo $CONDA_PREFIX/bin >>$GITHUB_PATH
       - name: Run pip install ${{ env.PIP_PKGS }}
         run: |

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -34,7 +34,7 @@ jobs:
             PIP_PKGS=pymbd
             RUN_PREFIX=
           else
-            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' 'mpi4py<4'"
+            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' mpi4py"
             PIP_PKGS="pymbd[mpi]"
             RUN_PREFIX="mpiexec -n 2"
           fi
@@ -58,7 +58,7 @@ jobs:
           echo "CONDA=/opt/homebrew/Caskroom/miniforge/base" >>$GITHUB_ENV
       - name: Create Conda environment
         run: |
-          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge "python<3.12" pip "setuptools<81" ${{ env.CONDA_PKGS }} numpy scipy
+          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge python pip ${{ env.CONDA_PKGS }} numpy scipy
           echo $CONDA_PREFIX/bin >>$GITHUB_PATH
       - name: Run pip install ${{ env.PIP_PKGS }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Runtime dependency on `pkg_resources`/`setuptools`; `pymbd` now uses `importlib.metadata` and `importlib.resources` ([#96](https://github.com/libmbd/libmbd/issues/96))
+- Runtime dependency on `pkg_resources`/`setuptools`; `pymbd` now uses `importlib.metadata` and `importlib.resources` ([#112](https://github.com/libmbd/libmbd/pull/112))
 - Support for Python < 3.10 ([#84](https://github.com/libmbd/libmbd/pull/84))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Runtime dependency on `pkg_resources`/`setuptools`; `pymbd` now uses `importlib.metadata` and `importlib.resources` ([#96](https://github.com/libmbd/libmbd/issues/96))
 - Support for Python < 3.10 ([#84](https://github.com/libmbd/libmbd/pull/84))
 
 ### Fixed

--- a/src/pymbd/__init__.py
+++ b/src/pymbd/__init__.py
@@ -1,13 +1,12 @@
 import re
-
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 from .pymbd import ang, from_volumes, mbd_energy, mbd_energy_species, screening
 
 __all__ = ['mbd_energy', 'mbd_energy_species', 'screening', 'ang', 'from_volumes']
 try:
-    __version__ = pkg_resources.get_distribution('pymbd').version
+    __version__ = version('pymbd')
     __version__ = re.split('[.-]', __version__, maxsplit=3)
     __version__ = (*map(int, __version__[:3]), *__version__[3:])
-except pkg_resources.DistributionNotFound:
+except PackageNotFoundError:
     __version__ = None

--- a/src/pymbd/pymbd.py
+++ b/src/pymbd/pymbd.py
@@ -4,12 +4,11 @@
 from __future__ import division, print_function
 
 import csv
-import sys
+from importlib.resources import files
 from itertools import product
 
 import numpy as np
 from numpy.polynomial.legendre import leggauss
-from pkg_resources import resource_string
 from scipy.special import erf, erfc
 
 __all__ = ['mbd_energy', 'mbd_energy_species', 'screening', 'ang']
@@ -301,9 +300,7 @@ def _array(obj, *args, **kwargs):
 
 
 def _get_vdw_params():
-    csv_lines = resource_string(__name__, 'vdw-params.csv').split(b'\n')
-    if sys.version_info[0] > 2:
-        csv_lines = [l.decode() for l in csv_lines]
+    csv_lines = (files(__package__) / 'vdw-params.csv').read_text().split('\n')
     reader = csv.DictReader(csv_lines, quoting=csv.QUOTE_NONNUMERIC)
     vdw_params = {row.pop('symbol'): row for row in reader}
     return vdw_params


### PR DESCRIPTION
Resolves the **prerequisite source changes** in the "After a new `pymbd` release on PyPI" group of #96. These need to land and be released *before* the `install.yaml` conda pins (#85/#86/#87) can be dropped.

## Changes

- **Drop `pkg_resources`** — `src/pymbd/__init__.py` now uses `importlib.metadata` (`version` / `PackageNotFoundError`) for version detection, and `src/pymbd/pymbd.py` uses `importlib.resources.files(...).read_text()` to load `vdw-params.csv`. The runtime no longer imports `setuptools` at all. The Python 2-era byte-decoding branch (`sys.version_info[0] > 2`) is removed along with it.
- CHANGELOG entry.

Already in place from earlier work (no change needed here):
- `mpi4py = { version = "^3 || ^4" }` in `pyproject.toml` (allows mpi4py 4.x)
- `poetry-core` is no longer vendored (build backend uses an unpinned `poetry-core`), so the next release won't pull in the removed `distutils`

## Follow-up (not in this PR)

Once a `pymbd` release containing these changes is on PyPI, a separate PR will drop the workaround conda pins in `install.yaml` — `python<3.12` (#85), `setuptools<81` (#86), `mpi4py<4` (#87). Doing it here would break the **Install** workflow (which installs `pymbd` from PyPI, i.e. the current release) until that release is cut.

## Verification

- `pymbd` imports cleanly; `__version__` resolves and all 483 vdW parameter rows load via the new `importlib.resources` path.
- `pytest tests/test_python.py` passes.
- `ruff check src/pymbd/` is clean.

https://claude.ai/code/session_01E557qyfGiGiknvuZpV9h36