### PR TITLE
docs: document CMake 3.22 and Python 3.10 minimum requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Calculated energy: -0.0002462647623817456
 
 ### libMBD
 
-libMBD uses CMake for compiling and installing, and requires a Fortran compiler, LAPACK, and optionally ScaLAPACK/MPI.
+libMBD uses CMake (≥ 3.22) for compiling and installing, and requires a Fortran compiler, LAPACK, and optionally ScaLAPACK/MPI.
 
 On Ubuntu:
 
@@ -76,7 +76,7 @@ This installs the libMBD shared library, C API header file,  high-level Fortran 
 
 ### pyMBD
 
-pyMBD can be installed and updated using [Pip](https://pip.pypa.io/en/stable/quickstart/), but requires installed libMBD as a dependency (see above).
+pyMBD requires Python ≥ 3.10 and can be installed and updated using [Pip](https://pip.pypa.io/en/stable/quickstart/), but requires installed libMBD as a dependency (see above).
 
 ```
 pip install pymbd


### PR DESCRIPTION
## Summary

The README installation prose did not reflect the toolchain floors that were recently raised in PR #84 (tracked under `[Unreleased]` in the CHANGELOG). The concrete minimum versions were enforced in the build/packaging config but not documented for users:

- `CMakeLists.txt` sets `cmake_minimum_required(VERSION 3.22)`
- `pyproject.toml` requires `python = "^3.10"`

This PR brings the README in sync with those requirements:

- Note **CMake ≥ 3.22** in the libMBD install section
- Note **Python ≥ 3.10** in the pyMBD install section

No functional changes; documentation only.

https://claude.ai/code/session_01LeAgEgdeR6Hrm88ZuH1vkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeAgEgdeR6Hrm88ZuH1vkS)_