### PR TITLE
Fix comm /= MPI_COMM_WORLD and add mpif.h CI coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,9 @@ jobs:
         include:
           - type: ubuntu
             mpi-nodes: 2
+          - type: ubuntu
+            mpi-nodes: 2
+            mpifh: mpifh
           - type: macos
             mpi-nodes: 2
           - type: nvhpc
@@ -173,6 +176,9 @@ jobs:
           fi
           if [[ "${{ matrix.mpi-nodes }}" ]]; then
               CMAKE_ARGS+=('-DENABLE_SCALAPACK_MPI=ON')
+          fi
+          if [[ "${{ matrix.mpifh }}" == "mpifh" ]]; then
+              CMAKE_ARGS+=('-DENABLE_MPIFH=ON')
           fi
           if [[ "${{ matrix.elsi }}" == "elsi" ]]; then
               CMAKE_ARGS+=('-DENABLE_ELSI=ON')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- BLACS grid is now sized from the actual MPI communicator passed to the geometry rather than from `MPI_COMM_WORLD`, fixing a crash in `BLACS_GRIDINIT` when a communicator with a different number of ranks is used ([#80](https://github.com/libmbd/libmbd/pull/80))
 - Library version determination from shallow Git clones ([#67](https://github.com/libmbd/libmbd/pull/67))
 
 ## [0.13.0] - 2024-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented origin and CC0-1.0 license of the bundled vdW parameter data ([#106](https://github.com/libmbd/libmbd/pull/106))
 - Support for `mpi4py` 4.x ([#84](https://github.com/libmbd/libmbd/pull/84))
+- `ENABLE_MPIFH` build option to compile against the legacy `mpif.h` MPI interface, now covered by CI ([#80](https://github.com/libmbd/libmbd/pull/80))
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ include(CTest)
 
 option(ENABLE_SCALAPACK_MPI "Enable parallelisation with ScaLAPACK/MPI")
 CMAKE_DEPENDENT_OPTION(ENABLE_ELSI "Enable ELSI interface" OFF ENABLE_SCALAPACK_MPI OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_MPIFH
+    "Use the legacy mpif.h MPI interface instead of the mpi/mpi_f08 Fortran module"
+    OFF ENABLE_SCALAPACK_MPI OFF)
 option(ENABLE_C_API "Enable C API" ON)
 
 option(BUILD_SHARED_LIBS "Build shared rather than static library" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(mbd
 
 if(ENABLE_SCALAPACK_MPI)
     target_sources(mbd PRIVATE mbd_mpi.F90 mbd_blacs.f90 mbd_scalapack.f90)
-    if(NOT MPI_Fortran_HAVE_F08_MODULE)
+    if(ENABLE_MPIFH OR NOT MPI_Fortran_HAVE_F08_MODULE)
         if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NAG")
             set(mismatch_flag "-mismatch")
         elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU"
@@ -65,7 +65,9 @@ target_include_directories(mbd
 if(ENABLE_SCALAPACK_MPI)
     target_link_libraries(mbd PRIVATE MPI::MPI_Fortran scalapack)
     set_property(TARGET mbd APPEND PROPERTY COMPILE_DEFINITIONS WITH_MPI WITH_SCALAPACK)
-    if(MPI_Fortran_HAVE_F08_MODULE)
+    if(ENABLE_MPIFH)
+        set_property(TARGET mbd APPEND PROPERTY COMPILE_DEFINITIONS WITH_MPIFH)
+    elseif(MPI_Fortran_HAVE_F08_MODULE)
         set_property(TARGET mbd APPEND PROPERTY COMPILE_DEFINITIONS WITH_MPIF08)
     endif()
 endif()

--- a/src/mbd_blacs.f90
+++ b/src/mbd_blacs.f90
@@ -86,30 +86,34 @@ end interface
 
 contains
 
-subroutine blacs_grid_init(this, comm)
-    use mpi
+subroutine blacs_grid_init(this, n_tasks, comm)
     class(blacs_grid_t), intent(inout) :: this
+    integer, intent(in), optional :: n_tasks
+        !! Number of processes to lay the grid over. When absent, the total
+        !! number of available BLACS processes is queried with BLACS_PINFO.
     integer, intent(in), optional :: comm
+        !! System context to build the grid on, e.g. an MPI communicator handle.
+        !! When absent, the default BLACS context is used.
 
-    integer :: my_task, n_tasks, nprows
-    integer :: ierr
+    integer :: my_task, nprocs, nprows
 
     if (present(comm)) then
-        call MPI_Comm_rank(comm, my_task, ierr)
-        call MPI_Comm_size(comm, n_tasks, ierr)
         this%comm = comm
         this%ctx = comm
     else
-        call BLACS_PINFO(my_task, n_tasks)
-        this%comm = MPI_COMM_WORLD
         call BLACS_GET(0, 0, this%ctx)
     end if
+    if (present(n_tasks)) then
+        nprocs = n_tasks
+    else
+        call BLACS_PINFO(my_task, nprocs)
+    end if
 
-    do nprows = int(sqrt(dble(n_tasks))), 1, -1
-        if (mod(n_tasks, nprows) == 0) exit
+    do nprows = int(sqrt(dble(nprocs))), 1, -1
+        if (mod(nprocs, nprows) == 0) exit
     end do
     this%nprows = nprows
-    this%npcols = n_tasks / this%nprows
+    this%npcols = nprocs / this%nprows
     call BLACS_GRIDINIT(this%ctx, 'R', this%nprows, this%npcols)
     call BLACS_GRIDINFO( &
         this%ctx, this%nprows, this%npcols, this%my_prow, this%my_pcol &

--- a/src/mbd_blacs.f90
+++ b/src/mbd_blacs.f90
@@ -87,23 +87,29 @@ end interface
 contains
 
 subroutine blacs_grid_init(this, comm)
+    use mpi
     class(blacs_grid_t), intent(inout) :: this
     integer, intent(in), optional :: comm
 
     integer :: my_task, n_tasks, nprows
+    integer :: ierr
 
-    call BLACS_PINFO(my_task, n_tasks)
+    if (present(comm)) then
+        call MPI_Comm_rank(comm, my_task, ierr)
+        call MPI_Comm_size(comm, n_tasks, ierr)
+        this%comm = comm
+        this%ctx = comm
+    else
+        call BLACS_PINFO(my_task, n_tasks)
+        this%comm = MPI_COMM_WORLD
+        call BLACS_GET(0, 0, this%ctx)
+    end if
+
     do nprows = int(sqrt(dble(n_tasks))), 1, -1
         if (mod(n_tasks, nprows) == 0) exit
     end do
     this%nprows = nprows
     this%npcols = n_tasks / this%nprows
-    if (present(comm)) then
-        this%ctx = comm
-        this%comm = comm
-    else
-        call BLACS_GET(0, 0, this%ctx)
-    end if
     call BLACS_GRIDINIT(this%ctx, 'R', this%nprows, this%npcols)
     call BLACS_GRIDINFO( &
         this%ctx, this%nprows, this%npcols, this%my_prow, this%my_pcol &

--- a/src/mbd_geom.F90
+++ b/src/mbd_geom.F90
@@ -169,9 +169,9 @@ subroutine geom_init(this)
     if (this%parallel_mode == 'auto' .or. this%parallel_mode == 'atoms') then
 #   ifdef WITH_MPI
 #       ifdef WITH_MPIF08
-        call this%blacs_grid%init(this%mpi_comm%mpi_val)
+        call this%blacs_grid%init(this%mpi_size, this%mpi_comm%mpi_val)
 #       else
-        call this%blacs_grid%init(this%mpi_comm)
+        call this%blacs_grid%init(this%mpi_size, this%mpi_comm)
 #       endif
 #   else
         call this%blacs_grid%init()


### PR DESCRIPTION
Builds on #80 (its commit is included verbatim, preserving @henriquemiranda's authorship) and extends it. Rebased on current `master` (incl. #116); merging this supersedes #80.

Three commits:

### 1. `Fix for comm /= MPI_COMM_WORLD` (#80, @henriquemiranda)
The original bugfix: the BLACS grid was sized from `BLACS_PINFO`, which always reports `MPI_COMM_WORLD`, so passing a communicator with a different number of ranks crashed `BLACS_GRIDINIT`. It is now sized from the actual communicator.

### 2. `Keep mbd_blacs free of MPI; pass task count from the caller`
#80 fixed the sizing by adding `use mpi` + an `MPI_Comm_size` call *inside* `mbd_blacs`. That couples the BLACS layer to a specific MPI Fortran interface (breaking `mpif.h`-only toolchains) and is at odds with BLACS being a message-passing abstraction that need not sit on MPI at all.

The only MPI-derived fact the grid needs is the **number of processes** — and `mbd_geom` (the MPI-aware layer) already computes `mpi_size` before initialising the grid. So this passes that count in: `blacs_grid_init` now takes optional `n_tasks` and `comm` (system context) arguments and falls back to the BLACS-native `BLACS_PINFO` when no count is given. As a result **`mbd_blacs` no longer references MPI in any form** (module, `mpif.h`, or symbol) and builds against `mpif.h`, the `mpi` module, and `mpi_f08` alike. The MPI knowledge stays where it belongs, and the BLACS layer reflects that BLACS itself is transport-agnostic.

### 3. `Add mpif.h build option and CI lane`
Adds the `ENABLE_MPIFH` CMake option (defines `WITH_MPIFH`) plus a CI lane that builds and runs it, giving coverage to the `mpif.h` code path (which existed — see the `WITH_MPIFH` fix in 0.4.2 — but was no longer reachable from the build). Argument-mismatch workaround flags are applied when the option is on.

Scope note: this is a **build-time** capability (compiling libMBD itself against `mpif.h` on toolchains lacking the modules) plus CI coverage. Letting `mpif.h`/legacy-`mpi` *callers* use the public API is already handled upstream by #116, so this does not subsume #79.

## Notes
- Validated locally: `fprettify` clean, CMake configures (incl. `-DENABLE_MPIFH=ON`), and the build compiles. The ScaLAPACK/MPI and new `mpif.h` builds are exercised by CI (no MPI toolchain in my environment).
- `blacs_grid_init` keeps treating the passed communicator handle directly as the BLACS context (`this%ctx = comm`), unchanged from before.

Opened as a draft.

https://claude.ai/code/session_018mPPrhysZ5jS5c5MLUkh4y