### PR TITLE
docs: fix CI status badge and remove defunct gitter chat badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libMBD
 
-![checks](https://img.shields.io/github/checks-status/libmbd/libmbd/master.svg)
+[![tests](https://img.shields.io/github/actions/workflow/status/libmbd/libmbd/tests.yaml?branch=master&label=tests)](https://github.com/libmbd/libmbd/actions/workflows/tests.yaml)
 [![coverage](https://img.shields.io/codecov/c/github/libmbd/libmbd.svg)](https://codecov.io/gh/libmbd/libmbd)
 ![python](https://img.shields.io/pypi/pyversions/pymbd.svg)
 [![conda](https://img.shields.io/conda/vn/conda-forge/libmbd.svg)](https://anaconda.org/conda-forge/libmbd)
@@ -9,7 +9,6 @@
 [![last commit](https://img.shields.io/github/last-commit/libmbd/libmbd.svg)](https://github.com/libmbd/libmbd/commits/master)
 [![license](https://img.shields.io/github/license/libmbd/libmbd.svg)](https://github.com/libmbd/libmbd/blob/master/LICENSE)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![chat](https://img.shields.io/gitter/room/libmbd/community)](https://gitter.im/libmbd/community)
 [![doi](https://img.shields.io/badge/doi-10%2Fk4bm-blue)](http://doi.org/k4bm)
 
 > libMBD: A general-purpose package for scalable quantum many-body dispersion calculations. [J. Hermann](https://github.com/jhrmnn), [M. Stöhr](https://github.com/martin-stoehr), S. Góger, [S. Chaudhuri](https://github.com/shaychaudhuri), [B. Aradi](https://github.com/aradi), [R. J. Maurer](https://github.com/reinimaurer1) & A. Tkatchenko. [*J. Chem. Phys.* **159**, 174802](http://doi.org/k4bm) (2023)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Calculated energy: -0.0002462647623817456
 
 ### libMBD
 
-libMBD uses CMake for compiling and installing, and requires a Fortran compiler, LAPACK, and optionally ScaLAPACK/MPI.
+libMBD uses CMake (≥ 3.22) for compiling and installing, and requires a Fortran compiler, LAPACK, and optionally ScaLAPACK/MPI.
 
 On Ubuntu:
 
@@ -76,7 +76,7 @@ This installs the libMBD shared library, C API header file,  high-level Fortran 
 
 ### pyMBD
 
-pyMBD can be installed and updated using [Pip](https://pip.pypa.io/en/stable/quickstart/), but requires installed libMBD as a dependency (see above).
+pyMBD requires Python ≥ 3.10 and can be installed and updated using [Pip](https://pip.pypa.io/en/stable/quickstart/), but requires installed libMBD as a dependency (see above).
 
 ```
 pip install pymbd


### PR DESCRIPTION
## Summary

Reviewed all README badges by fetching each one and inspecting its rendered output. Two needed attention:

- **CI status badge** — the `checks-status` endpoint rendered a perpetual `pending` and had no link. Replaced it with a GitHub Actions workflow-status badge for the **Tests** workflow (`tests.yaml`), which renders `passing` and links to the Actions page.
- **Gitter chat badge** — only rendered the `on gitter` fallback (Gitter is no longer active). Removed.

### Badges left unchanged (verified rendering correctly)
coverage (58%), conda (v0.12.8), pypi (v0.12.8), commits-since, last-commit, license (MPL-2.0), ruff, doi.

### Note (not fixed here)
The `python` (pypi/pyversions) badge currently shows `3.6–3.12` because it reads from the latest *published* PyPI release (0.12.8), which predates the Python ≥ 3.10 floor. It will self-correct on the next release; nothing to change in the README.

https://claude.ai/code/session_01LeAgEgdeR6Hrm88ZuH1vkS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeAgEgdeR6Hrm88ZuH1vkS)_