### PR TITLE
Use integer MPI handle in public API, keep mpi_f08 internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** The `comm` field of `mbd_input_t` is now always a plain integer MPI handle, even when the library is built against the `mpi_f08` module. The `mpi_f08` module is still used internally; callers using `mpi_f08` should pass `comm%mpi_val`. This makes the public API usable from code based on `mpif.h`/the legacy `mpi` module (see [#79](https://github.com/libmbd/libmbd/pull/79))
 - Minimum required CMake version is now 3.22 ([#84](https://github.com/libmbd/libmbd/pull/84))
 
 ### Removed

--- a/src/mbd.F90
+++ b/src/mbd.F90
@@ -40,7 +40,7 @@ type, public :: mbd_input_t
         !! MPI_COMM_WORLD communicator. The integer handle is accepted
         !! regardless of whether the library was built against the
         !! `mpi_f08` module; callers using `mpi_f08` should pass the
-        !! integer handle of their communicator (`comm%mpi_val`).
+        !! integer handle of their communicator (e.g. `mycomm%mpi_val`).
     integer :: max_atoms_per_block = MAX_ATOMS_PER_BLOCK
         !! Number of atoms per block in a BLACS grid.
     integer :: log_level = MBD_LOG_LVL_INFO

--- a/src/mbd.F90
+++ b/src/mbd.F90
@@ -12,9 +12,6 @@ use mbd_formulas, only: scale_with_ratio
 use mbd_geom, only: geom_t
 use mbd_gradients, only: grad_request_t, grad_t
 use mbd_methods, only: get_mbd_energy, get_mbd_scs_energy
-#ifdef WITH_MPIF08
-use mbd_mpi
-#endif
 use mbd_ts, only: get_ts_energy
 use mbd_utils, only: result_t, exception_t, printer_i
 use mbd_vdw_param, only: ts_vdw_params, tssurf_vdw_params, species_index
@@ -36,15 +33,14 @@ type, public :: mbd_input_t
         !! - `mbd-nl`: The MBD-NL method.
         !! - `ts`: The TS method.
         !! - `mbd`: Generic MBD method (without any screening).
-#ifdef WITH_MPIF08
-    type(MPI_Comm) :: comm = MPI_COMM_NULL
-#else
     integer :: comm = -1
-#endif
-        !! MPI communicator.
+        !! MPI communicator, as a plain integer handle.
         !!
         !! Only used when compiled with MPI. Leave as is to use the
-        !! MPI_COMM_WORLD communicator.
+        !! MPI_COMM_WORLD communicator. The integer handle is accepted
+        !! regardless of whether the library was built against the
+        !! `mpi_f08` module; callers using `mpi_f08` should pass the
+        !! integer handle of their communicator (`comm%mpi_val`).
     integer :: max_atoms_per_block = MAX_ATOMS_PER_BLOCK
         !! Number of atoms per block in a BLACS grid.
     integer :: log_level = MBD_LOG_LVL_INFO
@@ -154,12 +150,12 @@ subroutine mbd_calc_init(this, input)
         !! MBD input.
 
 #ifdef WITH_MPI
-#   ifdef WITH_MPIF08
-    if (input%comm /= MPI_COMM_NULL) then
-#   else
     if (input%comm /= -1) then
-#   endif
+#   ifdef WITH_MPIF08
+        this%geom%mpi_comm%mpi_val = input%comm
+#   else
         this%geom%mpi_comm = input%comm
+#   endif
     end if
 #endif
 #ifdef WITH_SCALAPACK


### PR DESCRIPTION
## Motivation

Since eba43f1 ("add support for the mpi_f08 module"), when CMake detects `MPI_Fortran_HAVE_F08_MODULE` it defines `WITH_MPIF08`, which changes the **public** type of `mbd_input_t%comm` from a plain `integer` to `type(MPI_Comm)`. As reported in #79, this makes the library unusable from caller code based on `mpif.h` or the legacy `mpi` module: such callers only have an `integer` communicator handle and have no `type(MPI_Comm)` object to pass, and the detection is automatic with no override.

## Relation to #79

This solves the same problem as #79, but in a different way. #79 adds a `FORCE_NO_MPIF08` CMake flag that lets the user force the plain-integer interface at build time (an either/or choice per build). This PR instead keeps using `mpi_f08` **internally** (preserving type safety and avoiding the `-fallow-argument-mismatch` workarounds) while making the public interface *always* a plain integer handle — so a single build works for both kinds of callers, with no flag to set. The two PRs are alternatives; this one is left for the maintainers to choose between (it does not auto-close #79).

## Change

- `mbd_input_t%comm` is now always a plain `integer` handle (default `-1`), regardless of whether the build uses `mpi_f08`.
- Internally, `geom_t%mpi_comm` and the `mpi_all_reduce` routines keep using `type(MPI_Comm)` when built with `mpi_f08`.
- In `mbd_calc_init`, the integer handle is bridged to the internal `type(MPI_Comm)` via its standard `mpi_val` component (`this%geom%mpi_comm%mpi_val = input%comm`). This component is guaranteed public by the MPI-3+ standard, and the codebase already relies on it (`mbd_geom.F90`).

This gives one public API that works for **both** worlds:
- `mpif.h` / legacy `mpi` callers pass their integer handle directly;
- `mpi_f08` callers pass `comm%mpi_val`.

## Breaking change

Code that was passing a `type(MPI_Comm)` to an `mpi_f08` build must now pass `comm%mpi_val` instead. Noted in the changelog under **Changed**.

## Why this does not re-trigger the gfortran 10+ argument-mismatch errors

The `-fallow-argument-mismatch` / `-mismatch` flags are required only when libmbd compiles its own MPI **calls** through the legacy untyped interfaces (`mpif.h`/`mpi` module), where the same routine is called with buffers of different types — hence they are already gated on `NOT MPI_Fortran_HAVE_F08_MODULE`. Here all internal MPI calls still go through `mpi_f08`'s strongly-typed generic interfaces. The public `comm` being an integer only adds a component assignment (`mpi_comm%mpi_val = comm`), which is not an MPI procedure call and triggers no interface check.

## Testing

- Built with `mpifort` + ScaLAPACK (CMake reports "Will use the mpi_f08 Fortran module"): **compiles cleanly, no argument-mismatch errors**, no mismatch flags applied.
- `ctest`: 42/42 pass in the `mpi_f08` build, and 42/42 in the non-MPI build.
- Standalone check against the `mpi_f08`-built `libmbd`: passing `MPI_COMM_WORLD%mpi_val` as `inp%comm` produces the correct Ar dimer energy in both serial and 2-rank `mpiexec` runs, exercising the new integer→`mpi_val` bridge.

https://claude.ai/code/session_01EBUASwpjeETCRu8k3SrjEX