### PR TITLE
Add shared-library VERSION/SOVERSION with a manually maintained SONAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented origin and CC0-1.0 license of the bundled vdW parameter data ([#106](https://github.com/libmbd/libmbd/pull/106))
 - Support for `mpi4py` 4.x ([#84](https://github.com/libmbd/libmbd/pull/84))
 - `ENABLE_MPIFH` CMake option for building against the legacy `mpif.h` interface, with CI coverage.
+- `VERSION`/`SOVERSION` on the shared library. The `SOVERSION` (SONAME) is a manually maintained integer (`MBD_SOVERSION`) tracking C-ABI compatibility, decoupled from the `0.x` release version ([#74](https://github.com/libmbd/libmbd/pull/74))
 
 ### Changed
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,11 @@ add_library(mbd
     mbd_vdw_param.f90
 )
 
+set_target_properties(mbd PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
 if(ENABLE_SCALAPACK_MPI)
     target_sources(mbd PRIVATE mbd_mpi.F90 mbd_blacs.f90 mbd_scalapack.f90)
     if(NOT MPI_Fortran_HAVE_F08_MODULE OR ENABLE_MPIFH)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,9 +24,20 @@ add_library(mbd
     mbd_vdw_param.f90
 )
 
+# Shared-library versioning. VERSION is informational and tracks the release
+# version (the full versioned library file). SOVERSION is the compatibility
+# version baked into the library identity (the SONAME on ELF, the
+# compatibility version on macOS) and must track the C-ABI (mbd.h)
+# compatibility only: bump MBD_SOVERSION by hand on every C-ABI break. It is
+# deliberately decoupled from the release version, which is 0.x and derived
+# from Git, so a major bump cannot be relied on to signal an ABI break. Note
+# this guards C consumers only; the Fortran .mod ABI is compiler-specific and
+# not covered by SOVERSION, so Fortran callers must rebuild against a matching
+# libMBD build regardless.
+set(MBD_SOVERSION 0)
 set_target_properties(mbd PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
+    SOVERSION ${MBD_SOVERSION}
 )
 
 if(ENABLE_SCALAPACK_MPI)


### PR DESCRIPTION
Builds on the idea in #74 (add `VERSION`/`SOVERSION` to the shared library) with a setup adapted to how libMBD actually versions itself.

## Why not derive SOVERSION from the version major

`SOVERSION` is the SONAME and should track **C-ABI compatibility**, which is a different axis from the release version. Deriving it from `PROJECT_VERSION_MAJOR` (as in #74) only works under a strict "major bump ⟺ ABI break" policy. libMBD is a `0.x` project whose version comes from `git describe`, so the major is pinned at `0` and the SONAME would be frozen at `libmbd.so.0` forever — even across genuine ABI breaks. That's worse than no SONAME: an old `libmbd.so.0` silently satisfies a link against an incompatible ABI.

This isn't hypothetical — the changelog already records a `0.x` C-ABI break:

> **Breaking:** The `comm` field of `mbd_input_t` is now always a plain integer MPI handle… (#79)

A version-derived SOVERSION would not have bumped through it.

## What this does

- **`VERSION`**: set from the parsed `major.minor.patch` release components (informational, the `libmbd.so.X.Y.Z` real file). Using these instead of the raw `PROJECT_VERSION` avoids embedding the full `git describe` string (e.g. `libmbd.so.0.13.0-50-g1234abc`) into non-release builds.
- **`SOVERSION`**: a hand-maintained `MBD_SOVERSION` integer, decoupled from the release version. Bump it whenever the `mbd.h` C ABI breaks.

Overhead is one integer plus a discipline note: touch the `mbd.h` ABI → bump `MBD_SOVERSION`.

## Caveat documented in the code

The SONAME guards **C** consumers only. The Fortran `.mod` ABI is compiler-specific (module format + name mangling) and not covered by any SONAME, so Fortran callers must rebuild against a matching libMBD build regardless. A comment in `src/CMakeLists.txt` records this so the SONAME isn't later overloaded with Fortran-ABI meaning.

## Verification

Built locally; produces the expected chain `libmbd.so` → `libmbd.so.0` (SONAME, confirmed via `objdump -p`) → `libmbd.so.X.Y.Z`.

Closes #74 in spirit — happy to instead rebase onto @LecrisUT's branch if the maintainers prefer to keep authorship there.

https://claude.ai/code/session_01Ka5D6JtYJ9spBQbGy1jQrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka5D6JtYJ9spBQbGy1jQrf)_