### PR TITLE
Don't run Install workflow on tag pushes

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
+    branches:
+      - '**'
     paths:
       - '.github/workflows/install.yaml'
 jobs:


### PR DESCRIPTION
## Problem

Tagging the `0.14.0` release triggered the **Install** workflow, which failed in two MPI matrix legs (`ubuntu/openmpi`, `macos/mpich`) at `mpiexec -n 2 python -m pymbd`:

```
assert PYMBD_VERSION[1] == LIBMBD_VERSION[1]
AssertionError
```

The workflow installs **libMBD from conda-forge** and **pyMBD from PyPI/the freshly built sdist**. Immediately after a release, conda-forge still serves the previous libMBD (`0.13.x`) until the feedstock is bumped, while pyMBD is already `0.14.0`. The `0.x` minor-version compatibility check in `src/pymbd/fortran.py` then fails. This is an inherent, transient post-release condition — not a real breakage — so running Install on a release tag is guaranteed noise.

## Why it ran at all

The `push` trigger already has a `paths` filter limiting it to changes in `install.yaml`, but **GitHub does not evaluate `paths`/`paths-ignore` filters for tag pushes**, so a tag push triggers the workflow regardless.

## Fix

Add a `branches: ['**']` filter to the `push` trigger. `branches` matches any branch but not tags, and when combined with `paths` both must be satisfied — so tag pushes no longer trigger the workflow. The weekly `schedule` run and the on-edit branch-push run are unaffected.

https://claude.ai/code/session_019Sfa9GjGKf5YahyfanPzZB

---
_Generated by [Claude Code](https://claude.ai/code/session_019Sfa9GjGKf5YahyfanPzZB)_