### PR TITLE
ci: drop install.yaml version pins resolved by pymbd 0.14.0

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -34,7 +34,7 @@ jobs:
             PIP_PKGS=pymbd
             RUN_PREFIX=
           else
-            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' 'mpi4py<4'"
+            CONDA_PKGS="libmbd='*=mpi_${{ matrix.mpi }}_*' mpi4py"
             PIP_PKGS="pymbd[mpi]"
             RUN_PREFIX="mpiexec -n 2"
           fi
@@ -58,7 +58,7 @@ jobs:
           echo "CONDA=/opt/homebrew/Caskroom/miniforge/base" >>$GITHUB_ENV
       - name: Create Conda environment
         run: |
-          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge "python<3.12" pip "setuptools<81" ${{ env.CONDA_PKGS }} numpy scipy
+          $CONDA/bin/conda create -p ${{ env.CONDA_PREFIX }} -c conda-forge python pip ${{ env.CONDA_PKGS }} numpy scipy
           echo $CONDA_PREFIX/bin >>$GITHUB_PATH
       - name: Run pip install ${{ env.PIP_PKGS }}
         run: |


### PR DESCRIPTION
Picks up the remaining deferred items from #84, now unblocked by the pymbd 0.14.0 release on PyPI.

The `install.yaml` smoke test installs the *released* `pymbd` from PyPI, so its conda env carried three workarounds for the previous release:

- **`python<3.12`** — the old release vendored a `poetry-core` that imported `distutils` (removed in Python 3.12+).
- **`setuptools<81`** — the old `pymbd/__init__.py` did `import pkg_resources`, which setuptools 81+ stopped auto-providing.
- **`mpi4py<4`** — the old release constrained `mpi4py = "^3"`, so installing 4.x forced pip to rebuild 3.x from source against modern setuptools.

[pymbd 0.14.0](https://github.com/libmbd/libmbd/releases/tag/0.14.0) drops the `pkg_resources`/`setuptools` runtime dependency (#112) and adds `mpi4py` 4.x support (#84), so all three pins can go.

### Checklist items addressed (from #84)

- [x] Drop `python<3.12` pin in `install.yaml`'s conda env
- [x] Drop `setuptools<81` pin in `install.yaml`'s conda env
- [x] Drop `mpi4py<4` pin in `install.yaml`'s conda env

The remaining deferred items in #84 (doc toolchain Sphinx/FORD pins, `B042`, etc.) are gated on separate prerequisites and are out of scope here.

https://claude.ai/code/session_01GK6LPkavNEh1Bhi5vgKbWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GK6LPkavNEh1Bhi5vgKbWt)_