### PR TITLE
Allow NumPy 2 and drop pytest pin, test both NumPy majors in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,11 @@ jobs:
         include:
           - type: ubuntu
             mpi-nodes: 2
+            numpy: "1"
           - type: ubuntu
             mpi-nodes: 4
             mpifh: mpifh
+            numpy: "2"
           - type: macos
             mpi-nodes: 2
           - type: nvhpc
@@ -84,7 +86,7 @@ jobs:
           path: |
             ${{ env.XDG_CACHE_HOME }}/conda/pkgs
             ${{ env.XDG_CACHE_HOME }}/pip
-          key: ${{ matrix.type }}-${{ matrix.python-version }}-${{ matrix.cmake-version }}-${{ matrix.gfortran-version }}-${{ matrix.mpi }}-${{ matrix.mpifh }}-${{ env.YEAR_MONTH }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ matrix.type }}-${{ matrix.python-version }}-${{ matrix.cmake-version }}-${{ matrix.gfortran-version }}-${{ matrix.mpi }}-${{ matrix.mpifh }}-${{ matrix.numpy }}-${{ env.YEAR_MONTH }}-${{ hashFiles('pyproject.toml') }}
       - name: Install libMBD dependencies
         if: matrix.type == 'ubuntu'
         run: sudo apt-get install -yq --no-install-suggests --no-install-recommends gfortran libblas-dev liblapack-dev mpi-default-dev mpi-default-bin libscalapack-mpi-dev
@@ -154,6 +156,12 @@ jobs:
         # The [toml] extra pulls in tomli so coverage can read its config from
         # pyproject.toml on the Python 3.10 legs (stdlib tomllib is 3.11+).
         run: pip install -U 'coverage[toml]'
+      - name: Pin numpy major version
+        # pyMBD supports both numpy 1.x and 2.x; pre-install the requested major
+        # so the subsequent pyMBD install keeps it (the dependency only sets a
+        # lower bound). Without a pin pip would always resolve the latest (2.x).
+        if: matrix.numpy != '' && matrix.type != 'conda'
+        run: pip install "numpy==${{ matrix.numpy }}.*"
       - name: Report environment
         run: |
           type python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,7 +160,9 @@ jobs:
         # pyMBD supports both numpy 1.x and 2.x; pre-install the requested major
         # so the subsequent pyMBD install keeps it (the dependency only sets a
         # lower bound). Without a pin pip would always resolve the latest (2.x).
-        if: matrix.numpy != '' && matrix.type != 'conda'
+        # `matrix.numpy` is null (falsy) on legs that don't set it, so the
+        # truthiness check skips them; only the ubuntu venv legs opt in.
+        if: matrix.numpy && matrix.type != 'conda'
         run: pip install "numpy==${{ matrix.numpy }}.*"
       - name: Report environment
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for NumPy 2.x, with CI covering both NumPy 1.x and 2.x
+
 ## [0.14.0] - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ generate-setup-file = false
 [tool.poetry.dependencies]
 python = "^3.10"
 scipy = "^1.6"
-numpy = "^1.20"
+numpy = ">=1.20"
 cffi = "^1"
-pytest = { version = "^6", optional = true }
+pytest = { version = "*", optional = true }
 mpi4py = { version = "^3 || ^4", optional = true }
 
 [tool.poetry.extras]

--- a/src/pymbd/benchmark.py
+++ b/src/pymbd/benchmark.py
@@ -79,7 +79,7 @@ def parse(output):
 
 def make_supercell(coords, lattice, species, vol_ratios, sc):
     sc = np.array(sc)
-    n_uc = np.product(sc)
+    n_uc = np.prod(sc)
     c = np.stack(
         np.meshgrid(range(sc[0]), range(sc[1]), range(sc[2])), axis=-1
     ).reshape(-1, 3)

--- a/src/pymbd/pymbd.py
+++ b/src/pymbd/pymbd.py
@@ -110,7 +110,7 @@ def dipole_matrix(
     coords, damping, beta=0.0, lattice=None, k_point=None, R_vdw=None, sigma=None, a=6.0
 ):
     if lattice is not None:
-        volume = max(np.abs(np.product(np.linalg.eigvals(lattice))), 0.2)
+        volume = max(np.abs(np.prod(np.linalg.eigvals(lattice))), 0.2)
         ewald_alpha = 2.5 / volume ** (1 / 3)
         real_space_cutoff = 6 / ewald_alpha
         range_cell = supercell_circum(lattice, real_space_cutoff)
@@ -151,7 +151,7 @@ def dipole_matrix(
 def dipole_matrix_ewald(coords, lattice, alpha, k_point=None):
     Rs = coords[:, None, :] - coords[None, :, :]
     rlattice = 2 * np.pi * np.linalg.inv(lattice.T)
-    volume = abs(np.product(np.linalg.eigvals(lattice)))
+    volume = abs(np.prod(np.linalg.eigvals(lattice)))
     rec_space_cutoff = 10 * alpha
     range_G_vector = supercell_circum(rlattice, rec_space_cutoff)
     dtype = float if k_point is None else complex


### PR DESCRIPTION
## Summary

Relaxes the dependency constraints so pyMBD works with NumPy 2.x and an
unpinned pytest, and extends CI to cover both NumPy major versions.

## Changes

- **`pyproject.toml`**
  - `numpy`: `^1.20` → `>=1.20` (allows both 1.x and 2.x)
  - `pytest`: drop the `^6` pin (now `*`)
- **`src/pymbd/pymbd.py`, `src/pymbd/benchmark.py`**: replace `np.product`
  with `np.prod` — `np.product` was removed in NumPy 2.0 and would otherwise
  break under NumPy 2.
- **`.github/workflows/tests.yaml`**: add a `numpy` major-version to the two
  ubuntu (venv) legs — one pinned to NumPy `1.*`, the other to `2.*` — via a
  new "Pin numpy major version" step. The conda legs already pull the latest
  (2.x) from conda-forge. The cache key now includes `matrix.numpy`.
- **`CHANGELOG.md`**: note NumPy 2.x support.

## Verification

Built libMBD + pyMBD in a fresh venv with **NumPy 2.4.6** and **pytest 9.0.3**
(both unpinned) and ran the full Python test suite — **28 passed**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXKxtc2yF3uVUipg7ccqo5)_