### PR TITLE
Allow cffi 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ generate-setup-file = false
 python = "^3.10"
 scipy = "^1.6"
 numpy = ">=1.20"
-cffi = "^1"
+cffi = ">=1"
 pytest = { version = "*", optional = true }
 mpi4py = { version = "^3 || ^4", optional = true }
 


### PR DESCRIPTION

Dear libmbd devs,

I am submitting this PR to facilitate integration of libmbd with other modern python packages in the same environment. The PR removes a version pin of the cffi dependency of pymbd to version 1. this simplifies my container setup quite a bit and my testing indicates that libmdb is in fact compatible with cffi in version 2. You can find more details below. I have used Claude Code to assist me in performing these changes and run the tests.

I wish you a nice day!

Kind Regards,
Paul Zeiger



## Summary

Relax the `cffi` dependency from `^1` (i.e. `>=1,<2`) to `>=1`, so pymbd can
be installed alongside cffi 2.x.

## Motivation

cffi 2.0 has been released. The current `<2` upper bound makes pymbd
uninstallable-without-downgrade in any environment that also needs cffi>=2 —
for example `cryptography>=44`, which requires `cffi>=2.0.0`. In a shared
environment the `<2` pin silently forces cffi back to 1.x and breaks those
packages (or the resolver simply refuses to install pymbd).

pymbd builds and runs correctly against cffi 2.x, so the cap is unnecessary.

## Changes

- `pyproject.toml`: `cffi = "^1"` → `cffi = ">=1"`

No source changes are required.

## Testing

Built libMBD and pymbd against **cffi 2.1.0** (numpy 2.3.0, Python 3.12) and
ran the full suite — all 28 tests pass, both the Fortran and pure-Python
backends:

``` bash
$ python -m pytest tests/
```