### PR TITLE
Work around a gfortran 16 -fcheck=bounds codegen bug in update_vdw_params_from_ratios

### DIFF
--- a/src/mbd.F90
+++ b/src/mbd.F90
@@ -283,15 +283,26 @@ subroutine mbd_calc_update_vdw_params_from_ratios(this, ratios)
 
     allocate (ones(size(ratios)), source=1d0)
     grad%dV = this%calculate_vdw_params_gradients
+    ! Alias free_values before slicing it into the scale_with_ratio calls.
+    ! Passing an array section of an allocatable rank-2 component of the
+    ! polymorphic `this` straight into an array-valued function makes gfortran 16
+    ! emit an -fcheck=bounds check that reads the component descriptor through a
+    ! null pointer -- a bogus bounds error at -O0, a segfault at -O1/-Og
+    ! (libmbd/libmbd#127; GCC PR<TBD>). Associating the component evaluates its
+    ! descriptor once and sidesteps the bad check; it is correct and idiomatic on
+    ! every compiler, so no version guard is needed. Do not fold the alias back
+    ! into `this%free_values(i, :)` while gfortran 16 is supported.
+    associate (free_values => this%free_values)
     this%alpha_0 = scale_with_ratio( &
-        this%free_values(1, :), ratios, ones, 1d0, this%dalpha_0, grad &
+        free_values(1, :), ratios, ones, 1d0, this%dalpha_0, grad &
     )
     this%C6 = scale_with_ratio( &
-        this%free_values(2, :), ratios, ones, 2d0, this%dC6, grad &
+        free_values(2, :), ratios, ones, 2d0, this%dC6, grad &
     )
     this%damp%r_vdw = scale_with_ratio( &
-        this%free_values(3, :), ratios, ones, 1d0 / 3, this%dr_vdw, grad &
+        free_values(3, :), ratios, ones, 1d0 / 3, this%dr_vdw, grad &
     )
+    end associate
     this%vdw_params_update = 'ratios'
 end subroutine
 


### PR DESCRIPTION
## Summary

Fixes the macOS CI failure on `master` (and every PR) since late June: `api/energy_from_ratios`, `api/hirshfeld_gradients` and `api/ts_gradients` segfaulted whenever libMBD was built with **gfortran 16 and `-fcheck=bounds`** — i.e. the default Debug flags (`-Og -fcheck=all`), which is what the `macos-latest` runners started using once their toolchain rolled to gcc 16. **This is a gfortran 16 compiler bug, not a libMBD bug.**

## Root cause

`update_vdw_params_from_ratios` passes an **array section of an allocatable rank-2 component** of the **polymorphic** passed-object `this` straight into an array-valued function:

```fortran
this%alpha_0 = scale_with_ratio(this%free_values(1, :), ratios, ones, 1d0, this%dalpha_0, grad)
```

gfortran 16 emits the `-fcheck=bounds` check for that section by reading `free_values`'s array descriptor **through a null object pointer**:

- at `-O0 -fcheck=bounds`: a **bogus** run-time error, `Index '1' of dimension 1 of array 'this%fv' outside of expected range (1:0)`;
- at `-O1`/`-O2`/`-Og` with `-fcheck=bounds`: **SIGSEGV** (`member access within null pointer of type 'struct …'` under UBSan).

The code is standard-conforming and compiles correctly on gfortran 13/14/15, Intel `ifx`, Intel `ifort`, and nvfortran. It reproduced identically on **arm64 (macOS)** and **x86-64 (Linux)**, so it is a gfortran 16 regression, not target-specific. Minimal essential ingredients (each load-bearing): polymorphic `this` + allocatable rank-2 component + array-**section** argument + array-valued function + `-fcheck=bounds` + optimization. Reduced to a ~25-line standalone testcase for an upstream GCC report (same family as PR 121185, still on trunk `r16-8100`).

## Fix

Alias the component with `associate` before slicing it, which evaluates its descriptor once and sidesteps the bad `-fcheck=bounds` code:

```fortran
associate (free_values => this%free_values)
    this%alpha_0    = scale_with_ratio(free_values(1, :), ...)
    this%C6         = scale_with_ratio(free_values(2, :), ...)
    this%damp%r_vdw = scale_with_ratio(free_values(3, :), ...)
end associate
```

`this` stays polymorphic; no preprocessor guard, no helper, no type change, no extra allocation. It's a correct, idiomatic F2003 reformulation on every compiler, so it's applied unconditionally (with a comment telling future maintainers not to fold the alias back while gfortran 16 is supported). `src/mbd.F90` only, +14/−3 lines.

## Testing

- **gfortran 13**, full `ctest`: **43/43** (values unchanged).
- **gfortran 16**, Debug (`-Og -fcheck=all`) — the three formerly-crashing tests: **pass**.
- Full pyMBD suite: 28/28.

## Notes

Separate from #126 (the `cffi` relaxation). A GCC bug report is being filed; the source comment carries a `PR<TBD>` placeholder to fill in with the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1qioBcciXpb3u7ibqUrZM