### PR TITLE
fix: avoid unassociated pointer in scalar real BLACS all-reduce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for NumPy 2.x, with CI covering both NumPy 1.x and 2.x
 
+### Fixed
+
+- Fixed a segmentation fault in ScaLAPACK/MPI builds, where the scalar real `blacs_all_reduce` wrote through an unassociated pointer; it now uses a plain array like its complex counterpart
+
 ## [0.14.0] - 2026-06-02
 
 ### Added

--- a/src/mbd_blacs.f90
+++ b/src/mbd_blacs.f90
@@ -193,7 +193,7 @@ subroutine all_reduce_real_scalar(x, blacs)
     real(dp), intent(inout) :: x
     type(blacs_desc_t), intent(in) :: blacs
 
-    real(dp), pointer :: x_arr(:, :)
+    real(dp) :: x_arr(1, 1)
 
     x_arr(1, 1) = x
     call DGSUM2D(blacs%ctx, 'A', ' ', 1, 1, x_arr, 1, -1, -1)


### PR DESCRIPTION
## Summary

Fixes the segmentation fault in the 2-rank ScaLAPACK/MPI test lanes (`All (macos, 2)`, `All (conda, =3.13, mpich, 2)`) that has been red on `master` since #126.

## Root cause

`all_reduce_real_scalar` in `src/mbd_blacs.f90` declared its scratch buffer as an **unassociated pointer** and then wrote through it:

```fortran
real(dp), pointer :: x_arr(:, :)   ! never allocated / associated
x_arr(1, 1) = x                    ! store through an unassociated pointer → UB
call DGSUM2D(..., x_arr, ...)
```

Writing to (and passing) an unassociated pointer is undefined behaviour. It stays benign on some toolchains and segfaults on others — which is exactly the observed CI pattern: the crash only hits the **newest** MPI stacks (latest conda `mpich`, Homebrew Open MPI 5 / `prterun`), while `mpich=4`-pinned, conda `openmpi`, and all Ubuntu lanes pass. The scalar real all-reduce is on the MBD energy-summation hot path (`matrix_re_sum_all` → `blacs_all_reduce`), which the failing `api/energy_from_ratios`, `api/hirshfeld_gradients`, and `api/ts_gradients` tests all exercise.

The **complex** counterpart `all_reduce_complex_scalar` (and the 1-D/2-D variants) handle their buffers correctly; only this one was wrong — a refactor/copy-paste slip.

## Fix

Use a plain array, identical to the complex twin:

```fortran
real(dp) :: x_arr(1, 1)
```

## Verification

- Built locally with `-DENABLE_SCALAPACK_MPI=ON` (Open MPI 4.1.6 + ScaLAPACK) and ran the full suite under 2 MPI ranks: **43/43 pass**, including the three tests that fail in CI.
- Open MPI 4.1.6 / gfortran 13 does **not** reproduce the crash even with `-fcheck=all` (the stray pointer descriptor happens to be usable there), consistent with the UB being toolchain-dependent — so the definitive check is CI running the `macos` and `conda mpich` lanes on this PR.

## Note

This is unrelated to the recent docs-domain migration (#128); it's the pre-existing MPI failure that the new docs-deploy gate correctly refuses to publish past. Once this is green on `master`, docs will deploy automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3oDJM7RWLk5XQkUAmM7pE

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3oDJM7RWLk5XQkUAmM7pE)_