### PR TITLE
Release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-17
+
 ### Added
 
-- Support for NumPy 2.x, with CI covering both NumPy 1.x and 2.x
+- Support for NumPy 2.x, with CI covering both NumPy 1.x and 2.x ([#124](https://github.com/libmbd/libmbd/pull/124))
+- Support for cffi 2.x ([#126](https://github.com/libmbd/libmbd/pull/126))
+
+### Fixed
+
+- Work around a gfortran 16 `-fcheck=bounds` codegen bug in the from-ratios vdW-parameter path ([#127](https://github.com/libmbd/libmbd/pull/127))
 
 ## [0.14.0] - 2026-06-02
 
@@ -267,7 +274,8 @@ Completely reworked.
 - Analytical gradients including lattice-vector derivatives.
 - Scalapack parallelization of all calculations.
 
-[unreleased]: https://github.com/libmbd/libmbd/compare/0.14.0...HEAD
+[unreleased]: https://github.com/libmbd/libmbd/compare/0.14.1...HEAD
+[0.14.1]: https://github.com/libmbd/libmbd/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/libmbd/libmbd/compare/0.12.8...0.14.0
 [0.12.8]: https://github.com/libmbd/libmbd/compare/0.12.7...0.12.8
 [0.12.7]: https://github.com/libmbd/libmbd/compare/0.12.6...0.12.7


### PR DESCRIPTION
Cut the 0.14.1 release, rolling up the user-facing changes accumulated since 0.14.0.

## Changelog

Moves the `[Unreleased]` items into a dated `[0.14.1]` section (following the same pattern as the 0.14.0 release in #120):

**Added**
- Support for NumPy 2.x, with CI covering both NumPy 1.x and 2.x (#124)
- Support for cffi 2.x (#126) — the change that prompted this release

**Fixed**
- Work around a gfortran 16 `-fcheck=bounds` codegen bug in the from-ratios vdW-parameter path (#127)

Also adds the `0.14.1` comparison link and repoints `[unreleased]` to `0.14.1...HEAD`.

## Notes

The package version is derived from the git tag via `poetry-dynamic-versioning`, so no source version strings need bumping. Publishing to PyPI and the GitHub Release is triggered by publishing a GitHub Release on the `0.14.1` tag once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXNU3YCut2HMuNSZpByh3o