### PR TITLE
ci: work around two external regressions breaking the conda MPI legs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,6 +75,16 @@ jobs:
           if [[ "${{ matrix.mpi }}" == "openmpi" || "${{ matrix.type }}" == "ubuntu" ]]; then
             echo MPIEXEC_EXTRA_FLAGS=--oversubscribe >>$GITHUB_ENV
           fi
+          # On the current GitHub-hosted (Azure) ubuntu runner image, conda
+          # MPICH (built on UCX) intermittently aborts at MPI_Init trying to
+          # open the Azure MANA (mana_0) RDMA/verbs device, and conda OpenMPI's
+          # vader BTL hits restrictive-ptrace CMA errors and then SIGSEGVs in
+          # heavy collectives. Every CI run is single-node, so pin both stacks
+          # to intra-node transports (shared memory + self) so they never touch
+          # the network device. Ignored by legs whose MPI does not use them.
+          echo UCX_TLS=sm,self >>$GITHUB_ENV
+          echo UCX_NET_DEVICES=lo >>$GITHUB_ENV
+          echo OMPI_MCA_btl_vader_single_copy_mechanism=none >>$GITHUB_ENV
           echo VIRTUAL_ENV=$HOME/env >>$GITHUB_ENV
           echo CONDA_PKGS_DIRS="$XDG_CACHE_HOME/conda/pkgs" >>$GITHUB_ENV
           echo $HOME/env/bin >>$GITHUB_PATH

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -156,7 +156,14 @@ jobs:
           echo "LD_LIBRARY_PATH=$nvroot/lib:$LD_LIBRARY_PATH" >>$GITHUB_ENV
       - name: Create Conda environment
         if: matrix.type == 'conda'
-        run: conda create -p ${{ env.VIRTUAL_ENV }} -c conda-forge python${{ matrix.python-version }} pip cmake${{ matrix.cmake-version }} gfortran_linux-64${{ matrix.gfortran-version }} openblas ${{ matrix.mpi }} scalapack elsi numpy scipy mpi4py
+        # openblas 0.3.34 SIGSEGVs in the LAPACK complex Hermitian eigensolver
+        # (ZHEEV, reached via ScaLAPACK PZHEEV) on the periodic MBD path, but
+        # only on some runner CPUs -- OpenBLAS dispatches CPU-specific kernels
+        # at runtime. Confirmed empirically: 0.3.33 passes, 0.3.34 crashes,
+        # nothing else in the env changed, and excluding it makes the legs
+        # green again. No matching upstream report yet; drop the exclusion once
+        # a fixed release lands.
+        run: conda create -p ${{ env.VIRTUAL_ENV }} -c conda-forge python${{ matrix.python-version }} pip cmake${{ matrix.cmake-version }} gfortran_linux-64${{ matrix.gfortran-version }} 'openblas!=0.3.34' ${{ matrix.mpi }} scalapack elsi numpy scipy mpi4py
       - name: Create Python virtual environment
         if: matrix.type != 'conda'
         run: |


### PR DESCRIPTION
Two **independent, external** regressions started breaking the conda MPI CI legs in mid-July. Neither is a libMBD bug. This PR works around both; the diff is 18 lines in `tests.yaml`.

## 1. GitHub runner image → UCX/vader MPI transport failures

When GitHub bumped the `ubuntu-latest` image (`ubuntu24/20260615.205` → `20260714.240`, between 07‑06 and 07‑15), the conda MPI legs began **intermittently** failing:

- **conda MPICH (UCX)** aborts at `MPI_Init` trying to open the Azure **MANA** (`mana_0`) RDMA/verbs device:
  ```
  UCX ERROR mana_0: iface ... failed to create UD QP ... Operation not supported
  MPIDI_UCX_init_world → MPI_Init failed → Fatal error in internal_Init
  ```
  → all 43 tests fail (nothing can start).
- **conda OpenMPI (vader BTL)** hits `CMA support not available due to restrictive ptrace settings` and SIGSEGVs in heavy collectives.

The conda packages were byte-identical across the flip (`mpich 4.3.2`, `openblas 0.3.33`), so the trigger is the runner image, not a dependency. It's intermittent even on the new image (some runs on `20260714.240` pass), consistent with the MANA verbs device misbehaving only on part of the fleet.

**Fix:** every CI run is single-node, so pin both stacks to intra-node transports so they never touch the network device — `UCX_TLS=sm,self` + `UCX_NET_DEVICES=lo` (MPICH/UCX) and `OMPI_MCA_btl_vader_single_copy_mechanism=none` (OpenMPI). Ignored by legs whose MPI doesn't use them.

## 2. OpenBLAS 0.3.34 → SIGSEGV in the complex eigensolver

Starting 07‑17, once conda resolved **openblas 0.3.34**, the **periodic/Ewald MBD** tests SIGSEGV inside `ScaLAPACK PZHEEV → node-local OpenBLAS ZHEEV`. The symbolized backtrace terminates in `src/mbd_scalapack.f90` `peigh_complex`; the real-valued (`PDSYEV`) path is unaffected.

It is **CPU-microarchitecture-dependent** (OpenBLAS dispatches kernels at runtime), so it fires only on some GitHub runners and never reproduces off that fleet with the identical package build (verified locally against byte-identical deps under ASan/Valgrind/`-fcheck` — all clean).

Established by **bisection**: every conda run on `openblas 0.3.33` (weeks of them) is clean; `0.3.34` crashes; `scalapack` and `mpich` were byte-identical across the flip. There is **no matching upstream OpenBLAS/conda-forge report**, so this is an empirical workaround, not a fix for a documented bug.

**Fix:** exclude `openblas != 0.3.34` in the conda env until a corrected release is available. Verified: with the exclusion, all conda MPI legs go green.

## Verification & scope

- With both fixes, the conda MPI legs pass (the `mpich, 2` and `openmpi, 8` legs that reproduced both crashes are green).
- A third, unrelated regression in the window — the **gfortran‑16 `-fcheck=bounds` from‑ratios** macOS crash (tests 41–43) — is **not** part of this PR; it was already fixed on master by #127/#130.
- Released 0.14.x binaries were built/tested against `openblas 0.3.33` and are unaffected by #2.

Both workarounds are intended to be temporary — drop them once GitHub's runner image and OpenBLAS ship fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZDGJ6E6Sm2Co7DK5RcVT7