### PR TITLE
ci: add aggregate gate job to Tests for branch protection

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -351,15 +351,15 @@ jobs:
         run: |
           make test -o test_libmbd | tee output
           ! grep failed output >/dev/null
-  gate:
-    # Single stable check that branch protection can require. It collapses the
-    # whole test matrix and both Intel legs into one job name, so the required-
-    # status-checks list never has to track individual matrix legs (which churn
-    # as the matrix changes). `always()` makes it run even when a dependency
-    # fails so it can report that failure; the guard mirrors the other jobs so
-    # it is skipped (not failed) on forks' scheduled runs.
-    if: always() && (github.event_name != 'schedule' || github.repository == 'libmbd/libmbd')
-    name: gate
+  pr-gate:
+    # Single stable check that branch protection can require on pull requests.
+    # It collapses the whole test matrix and both Intel legs into one job name,
+    # so the required-status-checks list never has to track individual matrix
+    # legs (which churn as the matrix changes). Only runs on pull_request
+    # events -- it exists purely to gate merges. `always()` makes it run even
+    # when a dependency fails so it can report that failure.
+    if: always() && github.event_name == 'pull_request'
+    name: PR gate
     needs: [all, intel]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -351,3 +351,20 @@ jobs:
         run: |
           make test -o test_libmbd | tee output
           ! grep failed output >/dev/null
+  gate:
+    # Single stable check that branch protection can require. It collapses the
+    # whole test matrix and both Intel legs into one job name, so the required-
+    # status-checks list never has to track individual matrix legs (which churn
+    # as the matrix changes). `always()` makes it run even when a dependency
+    # fails so it can report that failure; the guard mirrors the other jobs so
+    # it is skipped (not failed) on forks' scheduled runs.
+    if: always() && (github.event_name != 'schedule' || github.repository == 'libmbd/libmbd')
+    name: gate
+    needs: [all, intel]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any test job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "One or more test jobs failed, were cancelled, or were skipped."
+          exit 1


### PR DESCRIPTION
## Summary

Adds a single stable `PR gate` job to the **Tests** workflow (`tests.yaml`) that aggregates the entire test matrix (`all`) and both Intel legs (`intel`) into one check.

This is the repo-side prerequisite for making PR merges conditional on passing tests: a branch-protection rule / ruleset on `master` can require the single `PR gate` check instead of enumerating every matrix leg by name. Matrix legs churn as the matrix evolves, so requiring them directly is fragile; requiring `PR gate` is stable.

## Details

- Runs **only on `pull_request` events** — its sole purpose is to gate merges.
- Runs with `if: always()` so it still reports when a dependency fails (rather than being skipped along with the failure).
- Fails if any needed job's result is `failure`, `cancelled`, or `skipped`, and passes only when all test jobs succeed.

## Follow-up (outside this PR — requires repo admin)

Making tests actually block merges is a GitHub repository setting, not a code change. After this merges, a repo admin should configure a **branch protection rule / ruleset** on `master` with **Require status checks to pass before merging** enabled, requiring these stable checks:

- `PR gate` (Tests)
- `ruff` and `fprettify` (Lint)
- `Build` (Documentation)

All four names are stable, so the test matrix can change freely without drifting the required-checks list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)