### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-24
+
 ### Added
 
 - Analytic energy gradients for the RPA method, including the rescaled-eigenvalue variant ([#141](https://github.com/libmbd/libmbd/pull/141))
@@ -278,7 +280,8 @@ Completely reworked.
 - Analytical gradients including lattice-vector derivatives.
 - Scalapack parallelization of all calculations.
 
-[unreleased]: https://github.com/libmbd/libmbd/compare/0.14.1...HEAD
+[unreleased]: https://github.com/libmbd/libmbd/compare/0.15.0...HEAD
+[0.15.0]: https://github.com/libmbd/libmbd/compare/0.14.1...0.15.0
 [0.14.1]: https://github.com/libmbd/libmbd/compare/0.14.0...0.14.1
 [0.14.0]: https://github.com/libmbd/libmbd/compare/0.12.8...0.14.0
 [0.12.8]: https://github.com/libmbd/libmbd/compare/0.12.7...0.12.8


### PR DESCRIPTION
Cut the 0.15.0 release, rolling up the user-facing changes accumulated since 0.14.1.

## Changelog

Moves the `[Unreleased]` items into a dated `[0.15.0]` section (same pattern as 0.14.1 in #131):

**Added**
- Analytic energy gradients for the RPA method, including the rescaled-eigenvalue variant (#141)

Also adds the `0.15.0` comparison link and repoints `[unreleased]` to `0.15.0...HEAD`.

## Notes

The package version is derived from the git tag via `poetry-dynamic-versioning`, so no source version strings need bumping.

Per `.github/workflows/release.yaml`, merging this PR **with the `release` label** tags the merge commit `0.15.0`, builds the archives, and opens a **draft** GitHub Release for a maintainer to publish by hand. This is the first release cut through that label-gated flow (it postdates 0.14.1), so the `release` label needs to exist and be applied for the automation to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4yeebkHEZXhNuyZDW7YHS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4yeebkHEZXhNuyZDW7YHS)_