### PR TITLE
Prefix drafted GitHub Release title with libMBD

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           else
             gh release create "$TAG" \
               --draft \
-              --title "$TAG" \
+              --title "libMBD $TAG" \
               --notes-file release-notes.md \
               dist/*.tar.gz
           fi


### PR DESCRIPTION
## Summary

The release workflow created the draft GitHub Release with `--title "$TAG"`, so the release name was the bare version (e.g. `0.15.0`). This changes it to `libMBD $TAG` so the release title is self-describing (e.g. `libMBD 0.15.0`).

## Notes

- Only the create branch sets a title; the update-in-place branch (`gh release upload --clobber`) leaves the title untouched, so existing drafts aren't renamed by a re-run.
- The already-drafted `0.15.0` release (from #142) keeps its `0.15.0` title and would need a one-off manual rename; this fix applies to `0.15.0` onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4yeebkHEZXhNuyZDW7YHS

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4yeebkHEZXhNuyZDW7YHS)_