### PR TITLE
Allow custom k-points in the high-level Fortran API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Custom k-points in the high-level Fortran API via `mbd_input_t%custom_k_pts` ([#6](https://github.com/libmbd/libmbd/issues/6))
+
 ## [0.15.0] - 2026-07-24
 
 ### Added

--- a/src/mbd.F90
+++ b/src/mbd.F90
@@ -100,6 +100,13 @@ type, public :: mbd_input_t
         !! periodic.
     integer :: k_grid(3) = [-1, -1, -1]
         !! Number of \(k\)-points along reciprocal axes.
+    real(dp), allocatable :: custom_k_pts(:, :)
+        !! (\(3\times N_k\), a.u.) Custom \(k\)-points in reciprocal space as
+        !! columns.
+        !!
+        !! An alternative to specifying a regular Monkhorst–Pack-style grid via
+        !! [[mbd_input_t:k_grid]]. When allocated, these \(k\)-points are used
+        !! instead of a grid generated from `k_grid`.
     character(len=10) :: parallel_mode = 'auto'
         !! Parallelization scheme.
         !!
@@ -173,13 +180,15 @@ subroutine mbd_calc_init(this, input)
     this%geom%param%k_grid_shift = input%k_grid_shift
     this%geom%param%zero_negative_eigvals = input%zero_negative_eigvals
     if (.not. all(input%k_grid == -1)) this%geom%k_grid = input%k_grid
+    if (allocated(input%custom_k_pts)) this%geom%custom_k_pts = input%custom_k_pts
     this%geom%coords = input%coords
     if (allocated(input%lattice_vectors)) then
-        if (input%method /= 'ts' .and. .not. allocated(this%geom%k_grid)) then
+        if (input%method /= 'ts' .and. .not. allocated(this%geom%k_grid) &
+                .and. .not. allocated(this%geom%custom_k_pts)) then
             this%geom%exc = exception_t( &
                 MBD_EXC_INPUT, &
                 'calc%init()', &
-                'Lattice vectors present but no k-grid specified' &
+                'Lattice vectors present but no k-points specified' &
             )
             return
         end if

--- a/src/mbd_methods.F90
+++ b/src/mbd_methods.F90
@@ -90,6 +90,11 @@ type(result_t) function get_mbd_energy(geom, alpha_0, C6, damp, grad) result(res
     else
         if (allocated(geom%custom_k_pts)) then
             k_pts = geom%custom_k_pts
+            ! Custom k-points are fixed absolute points in reciprocal space and
+            ! are treated as independent of the lattice, so their contribution
+            ! to the lattice derivative vanishes.
+            if (grad%dlattice) &
+                allocate (dkdlattice(3, size(k_pts, 2), 3, 3), source=0d0)
         else
             call make_k_pts( &
                 k_pts, geom%k_grid, geom%lattice, geom%param%k_grid_shift, &

--- a/tests/mbd_api_tests.F90
+++ b/tests/mbd_api_tests.F90
@@ -36,8 +36,8 @@ subroutine test(test_name)
     character(len=*), intent(in) :: test_name
 
     type(mbd_input_t) :: inp
-    type(mbd_calc_t) :: calc
-    real(dp) :: energy
+    type(mbd_calc_t) :: calc, calc_grid
+    real(dp) :: energy, energy_grid
     real(dp), allocatable :: gradients(:, :)
     integer :: code
     character(200) :: origin, msg
@@ -132,6 +132,25 @@ subroutine test(test_name)
         allocate (gradients(3, 2))
         call calc%get_gradients(gradients)
         call check(sum(abs(gradients)), 3.8405275467790542d-4, 1d-10)
+    case ('custom_k_pts')
+        ! A single custom Gamma point must reproduce a Gamma-only regular grid
+        ! (k_grid = [1, 1, 1] with no off-Gamma shift).
+        inp%lattice_vectors = reshape( &
+            [8d0 * ang, 0d0, 0d0, 0d0, 8d0 * ang, 0d0, 0d0, 0d0, 8d0 * ang], [3, 3])
+        inp%k_grid_shift = 0d0
+        inp%k_grid = [1, 1, 1]
+        call calc_grid%init(inp)
+        call calc_grid%update_vdw_params_custom( &
+            [11d0, 11d0], [63.525d0, 63.525d0], [3.55d0, 3.55d0])
+        call calc_grid%evaluate_vdw_method(energy_grid)
+        call calc_grid%destroy()
+        inp%k_grid = [-1, -1, -1]
+        inp%custom_k_pts = reshape([0d0, 0d0, 0d0], [3, 1])
+        call calc%init(inp)
+        call calc%update_vdw_params_custom( &
+            [11d0, 11d0], [63.525d0, 63.525d0], [3.55d0, 3.55d0])
+        call calc%evaluate_vdw_method(energy)
+        call check(energy, energy_grid, 1d-10)
     end select
     call calc%destroy()
 end subroutine


### PR DESCRIPTION
## Summary

Closes #6.

Custom reciprocal-space k-points were already accepted by the low-level `geom_t` type and by the C/Python APIs (`MBDGeom(custom_k_pts=...)`, added in 0.6.0), but the high-level Fortran API (`mbd_input_t` / `mbd_calc_t`) only exposed a regular `k_grid`. This PR closes that gap.

## Changes

- **`src/mbd.F90`** — add an allocatable `custom_k_pts(:, :)` field to `mbd_input_t` (shape `(3, N_k)`, columns are k-points in a.u., matching `geom_t%custom_k_pts` and the C API). Wire it into `mbd_calc_init`, and let an allocated `custom_k_pts` satisfy the "lattice present but no k-points" input validation in place of `k_grid`.
- **`src/mbd_methods.F90`** — treat custom k-points as fixed absolute points that are independent of the lattice, so their contribution to the lattice derivative is zero. This also fixes a latent out-of-bounds access on the unallocated `dkdlattice` array that was triggered whenever lattice gradients (the default, `calculate_forces = .true.`) were requested together with custom k-points.
- **`tests/mbd_api_tests.F90`** — add an `api/custom_k_pts` case: a single custom Γ point must reproduce the energy of a Γ-only regular grid (`k_grid = [1, 1, 1]`, no off-Γ shift), exercising the gradient path as well.
- **`CHANGELOG.md`** — note the addition under `[Unreleased]`.

## Testing

- `ctest --test-dir build` — all 60 Fortran tests pass, including the new `api/custom_k_pts`.
- `pytest tests/test_fortran.py` — all 23 Python tests pass (existing C/Python `custom_k_pts` path unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4XYMRuCNDQ9cUZxCBVN7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4XYMRuCNDQ9cUZxCBVN7e)_