### PR TITLE
Add optional PySCF → pyMBD bridge (pymbd.pyscf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `pymbd.pyscf` bridge turning a converged PySCF Kohn–Sham object into an MBD or TS dispersion energy via Hirshfeld volume ratios ([#145](https://github.com/libmbd/libmbd/pull/145))
+
 ## [0.15.0] - 2026-07-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Notes for Claude
+
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and is maintained by hand. Add an entry for a user-visible change as part of the
+change itself, not as a follow-up:
+
+- Put it under `## [Unreleased]`, in one of the categories the file already uses
+  — `Added`, `Changed`, `Removed`, `Fixed` — adding the `###` heading if that
+  category is not there yet.
+- Link the pull request or issue it came from:
+  `- Support for cffi 2.x ([#126](https://github.com/libmbd/libmbd/pull/126))`
+- Say what changed from the outside, for someone deciding whether an upgrade
+  affects them, rather than how it was implemented. Prefix a breaking change
+  with `**Breaking:**`.
+
+**Never add a `## [X.Y.Z]` version heading.** The release workflow reads the
+version from the topmost one and tags a release from it, so inventing a heading
+starts a release. Turning `[Unreleased]` into a version is the release process's
+job — see `RELEASING.md`.
+
+Changes with no effect a user could observe — refactoring, tests, CI,
+documentation, build plumbing — get no entry. Leave them out rather than padding
+the list.

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -22,16 +22,18 @@ MBD MAE of 0.037 kcal/mol against def2-TZVP's 0.018, and the gap is concentrated
 in the systems with pi systems (0.11 for pyridine-ethene, 0.09 for
 uracil-ethyne, against 0.005-0.009 for the small hydrogen-bonded ones).
 
-The integration grid, by contrast, hardly matters, because the same grid
-integrates the in-molecule and the free-atom volume and its error largely
-cancels in their ratio. Between PySCF grid levels 0 and 4 the MBD interaction
-energy of a 17-atom dimer moves by 7e-4 kcal/mol, two orders of magnitude below
-the deviation being measured, while the SCF energy moves by 16 kcal/mol. This
-script only validates the MBD term, so it defaults to level 0 and takes the
-speedup. The DFT (PBE) term is reported alongside, but at this grid its residual
-against the all-electron reference is dominated by grid error, on top of the
-basis set and (no counterpoise) BSSE -- raise --grid before reading anything
-into it. None of it is a bridge effect.
+The integration grid matters much less than it does for the DFT, because the
+same grid integrates the in-molecule and the free-atom volume and its error
+largely cancels in their ratio, so this script defaults to level 1 rather than
+PySCF's 3. It does not survive level 0, though, and how far it survives is
+system-dependent: on an aromatic dimer levels 0 to 4 span 7e-4 kcal/mol, but on
+pentane-pentane, the most hydrogen-rich system in S66, level 0 is 0.029 off
+while level 1 is within 3e-4 of a converged grid. Hydrogen carries the coarsest
+atomic grid, so the aliphatic systems set the requirement. The DFT (PBE) term is
+reported alongside, but at this grid its residual against the all-electron
+reference has a grid component, on top of the basis set and (no counterpoise)
+BSSE -- raise --grid before reading anything into it. None of it is a bridge
+effect.
 
 The SCF convergence threshold can be loosened a long way for the same reason, so
 it defaults to 1e-4 rather than PySCF's 1e-9. Measured over the default subset
@@ -195,8 +197,8 @@ def main(argv=None):
     p.add_argument(
         '--grid',
         type=int,
-        default=0,
-        help='PySCF grid level (default 0: enough for MBD, see the module '
+        default=1,
+        help='PySCF grid level (default 1: enough for MBD, see the module '
         'docstring, but too coarse for the DFT energies)',
     )
     p.add_argument(

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -13,9 +13,10 @@ point, with the FHI-aims MBD energies of
 
 whose processed results are published on figshare. Because FHI-aims shares no
 code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
-term is an independent cross-code validation of the bridge. The DFT (PBE) term
-is also reported: its residual against the all-electron reference is a
-basis-set effect, not a bridge effect.
+term is an independent cross-code validation of the bridge; it currently agrees
+to ~0.003 kcal/mol MAE. The DFT (PBE) term is also reported: its residual
+against the all-electron reference is a basis-set (and, without counterpoise,
+BSSE) effect, not a bridge effect.
 
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -133,16 +133,24 @@ def load_paper(h5_path):
 _ENERGIES = {}
 
 
-def our_energies(species, coords, basis, xc, grid):
-    """Return (SCF energy, MBD energy) for one fragment, memoized on its geometry.
+def our_energies(species, coords, basis, xc, grid, dm0=None):
+    """Return (SCF energy, MBD energy, density matrix) for one fragment.
 
-    The two monomers of a system are taken at its equilibrium separation whatever
-    the separation of the complex, so they are the same fragment at all eight
-    points of a dissociation curve and only need computing once.
+    Memoized on the geometry: the two monomers of a system are taken at its
+    equilibrium separation whatever the separation of the complex, so they are the
+    same fragment at all eight points of a dissociation curve and only need
+    computing once. The density matrix is returned for chaining (below) and is
+    None on a cache hit, since it is not worth keeping every fragment's.
+
+    ``dm0`` is an initial guess, meant to be the converged density of the previous
+    point of a dissociation curve. The monomers are rigid along one, so successive
+    complexes differ only in their separation and the previous density is a good
+    starting point. It cannot change the converged result and so is deliberately
+    not part of the cache key.
     """
     key = (basis, xc, grid, tuple(species), tuple(map(tuple, coords)))
     if key in _ENERGIES:
-        return _ENERGIES[key]
+        return (*_ENERGIES[key], None)
 
     from pyscf import dft, gto
 
@@ -156,9 +164,9 @@ def our_energies(species, coords, basis, xc, grid):
     )
     mf = dft.RKS(mol, xc=xc).density_fit()
     mf.grids.level = grid
-    mf.kernel()
+    mf.kernel(dm0=dm0)
     _ENERGIES[key] = (mf.e_tot, mbd_energy(mf, beta=MBD_BETA))
-    return _ENERGIES[key]
+    return (*_ENERGIES[key], mf.make_rdm1())
 
 
 def main(argv=None):
@@ -189,14 +197,22 @@ def main(argv=None):
 
     rows = []
     seen = set()
+    # the converged density of the previous point of the current dissociation
+    # curve, fed to the next one as its initial guess; only one is ever held,
+    # since the points arrive grouped by system
+    curve_idx, curve_dm = None, None
     for idx, label, scale, frags in load_geometries(args.vdwsets, idx_filter):
         key = (_norm(label), float(scale))
         if key not in mbd_ref:
             continue
-        e = {
-            name: our_energies(*g, args.basis, args.xc, args.grid)
-            for name, g in frags.items()
-        }
+        if idx != curve_idx:
+            curve_idx, curve_dm = idx, None
+        e = {}
+        for name, g in frags.items():
+            guess = curve_dm if name == 'complex' else None
+            *e[name], dm = our_energies(*g, args.basis, args.xc, args.grid, guess)
+            if name == 'complex':
+                curve_dm = dm
         pbe_int = (e['complex'][0] - e['fragment-1'][0] - e['fragment-2'][0]) * AU2KCAL
         mbd_int = (e['complex'][1] - e['fragment-1'][1] - e['fragment-2'][1]) * AU2KCAL
         rows.append(

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -33,6 +33,13 @@ against the all-electron reference is dominated by grid error, on top of the
 basis set and (no counterpoise) BSSE -- raise --grid before reading anything
 into it. None of it is a bridge effect.
 
+The SCF convergence threshold can be loosened a long way for the same reason.
+Over the default subset, --conv-tol 1e-4 moves the MBD energies by ~5e-5
+kcal/mol while taking the run from 220 s to 139 s; 1e-2 takes it to 123 s but
+the energies then scatter by 0.0035 kcal/mol on average and 0.012 at worst,
+which is an appreciable fraction of the deviation being measured, and it is
+scatter rather than a bias, so it does not average out.
+
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
     (article 5117167, "dft-vdw-range Data")
@@ -133,7 +140,7 @@ def load_paper(h5_path):
 _ENERGIES = {}
 
 
-def our_energies(species, coords, basis, xc, grid, dm0=None):
+def our_energies(species, coords, basis, xc, grid, conv_tol, dm0=None):
     """Return (SCF energy, MBD energy, density matrix) for one fragment.
 
     Memoized on the geometry: the two monomers of a system are taken at its
@@ -148,7 +155,7 @@ def our_energies(species, coords, basis, xc, grid, dm0=None):
     starting point. It cannot change the converged result and so is deliberately
     not part of the cache key.
     """
-    key = (basis, xc, grid, tuple(species), tuple(map(tuple, coords)))
+    key = (basis, xc, grid, conv_tol, tuple(species), tuple(map(tuple, coords)))
     if key in _ENERGIES:
         return (*_ENERGIES[key], None)
 
@@ -164,6 +171,7 @@ def our_energies(species, coords, basis, xc, grid, dm0=None):
     )
     mf = dft.RKS(mol, xc=xc).density_fit()
     mf.grids.level = grid
+    mf.conv_tol = conv_tol
     mf.kernel(dm0=dm0)
     _ENERGIES[key] = (mf.e_tot, mbd_energy(mf, beta=MBD_BETA))
     return (*_ENERGIES[key], mf.make_rdm1())
@@ -181,6 +189,12 @@ def main(argv=None):
         default=0,
         help='PySCF grid level (default 0: enough for MBD, see the module '
         'docstring, but too coarse for the DFT energies)',
+    )
+    p.add_argument(
+        '--conv-tol',
+        type=float,
+        default=1e-9,
+        help="SCF convergence threshold (PySCF's own default is 1e-9)",
     )
     p.add_argument(
         '--idx',
@@ -210,7 +224,9 @@ def main(argv=None):
         e = {}
         for name, g in frags.items():
             guess = curve_dm if name == 'complex' else None
-            *e[name], dm = our_energies(*g, args.basis, args.xc, args.grid, guess)
+            *e[name], dm = our_energies(
+                *g, args.basis, args.xc, args.grid, args.conv_tol, guess
+            )
             if name == 'complex':
                 curve_dm = dm
         pbe_int = (e['complex'][0] - e['fragment-1'][0] - e['fragment-2'][0]) * AU2KCAL
@@ -247,7 +263,8 @@ def main(argv=None):
         f'max|Δ| {np.abs(dmbd).max():.4f}  bias {dmbd.mean():+.4f} kcal/mol'
     )
     print(
-        f'PBE  (our {args.basis}, grid {args.grid}, no CP, vs all-electron):  '
+        f'PBE  (our {args.basis}, grid {args.grid}, conv {args.conv_tol:g}, no CP, '
+        f'vs all-electron):  '
         f'MAE {np.abs(dpbe).mean():.4f}  bias {dpbe.mean():+.4f} kcal/mol  '
         f'(basis set + BSSE + grid, not the bridge)'
     )

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -121,7 +121,20 @@ def load_paper(h5_path):
     return pbe, mbd, ref
 
 
+_ENERGIES = {}
+
+
 def our_energies(species, coords, basis, xc):
+    """Return (SCF energy, MBD energy) for one fragment, memoized on its geometry.
+
+    The two monomers of a system are taken at its equilibrium separation whatever
+    the separation of the complex, so they are the same fragment at all eight
+    points of a dissociation curve and only need computing once.
+    """
+    key = (basis, xc, tuple(species), tuple(map(tuple, coords)))
+    if key in _ENERGIES:
+        return _ENERGIES[key]
+
     from pyscf import dft, gto
 
     from pymbd.pyscf import mbd_energy
@@ -134,7 +147,8 @@ def our_energies(species, coords, basis, xc):
     )
     mf = dft.RKS(mol, xc=xc).density_fit()
     mf.kernel()
-    return mf.e_tot, mbd_energy(mf, beta=MBD_BETA)
+    _ENERGIES[key] = (mf.e_tot, mbd_energy(mf, beta=MBD_BETA))
+    return _ENERGIES[key]
 
 
 def main(argv=None):

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -14,7 +14,10 @@ point, with the FHI-aims MBD energies of
 whose processed results are published on figshare. Because FHI-aims shares no
 code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
 term is an independent cross-code validation of the bridge; it currently agrees
-to ~0.003 kcal/mol MAE. The DFT (PBE) term is also reported: its residual
+to ~0.006 kcal/mol MAE in the default def2-SVP basis (~0.003 in def2-TZVP).
+The MBD term is only weakly basis-dependent, because the free-atom reference is
+taken in the same basis and cancels its incompleteness, so the cheap basis is
+enough to validate the bridge. The DFT (PBE) term is also reported: its residual
 against the all-electron reference is a basis-set (and, without counterpoise,
 BSSE) effect, not a bridge effect.
 
@@ -26,7 +29,7 @@ Data (downloaded/located, not shipped):
 
 Usage:
     python pyscf_s66x8_figshare_check.py --vdwsets /path/to/vdwsets/clone \\
-        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-tzvp]
+        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-svp]
 """
 
 import argparse
@@ -127,7 +130,7 @@ def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--vdwsets', required=True, help='path to a vdwsets checkout')
     p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
-    p.add_argument('--basis', default='def2-tzvp')
+    p.add_argument('--basis', default='def2-svp')
     p.add_argument('--xc', default='PBE')
     p.add_argument(
         '--idx',

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -16,75 +16,44 @@ code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
 term is an independent cross-code validation of the bridge.
 
 Besides the MBD term itself the summary reports what that deviation is worth on
-the benchmark the method is actually judged by, as a MARE against the CCSD(T)/CBS
-S66x8 reference energies. The reconstructed total puts our MBD term on top of the
-*reference's* own all-electron PBE interaction energy rather than ours, so the DFT
-part is identical in both totals and the whole gap between the reconstructed and
-the reference MARE is the bridge. Using our PBE would drown it: uncorrected for
-BSSE and in a finite basis that term is off by of order 1 kcal/mol, against the
-~0.03 the MBD term is being judged on. Over the full set (--all) the reference
-row reproduces the published MAE 0.318 / MARE 10.1%, which doubles as a check on
-the surrounding machinery, and the reconstructed MARE is 10.1% in aug-cc-pVDZ,
-10.6% in def2-TZVP and 11.4% in def2-SVP, against 65.6% with no dispersion.
+the benchmark the method is judged by, as a MARE against the CCSD(T)/CBS S66x8
+reference energies. Both the reconstructed and the reference total take the DFT
+part from the reference's own all-electron PBE interaction energies, so the DFT
+is identical in the two and the whole gap between them is the dispersion term.
+Using our PBE instead would drown it, being uncorrected for BSSE and in a finite
+basis. Both are broken down by separation alongside the relative MBD deviation,
+since that deviation is very nearly a pure systematic offset and so cancels
+against the reference's own error at some separations and compounds at others --
+which means a basis can rank well on the compressed geometries for reasons that
+reverse at long range.
 
-Both are also broken down by separation, which is where the two ways of being
-wrong separate. The MBD deviation is a nearly pure systematic offset -- in every
-basis tried the MAE equals the bias to four decimals and 96-99% of points deviate
-in the same direction -- so it partly cancels against the reference's own error at
-some separations and compounds at others. def2-SVP is the sharpest illustration:
-it scores better than the reference at the most compressed geometry (22.4% against
-26.6%) and worst of all at the longest (8.4% against 4.5%). Ranking bases on the
-short separations alone orders them backwards.
+The defaults are all chosen for the MBD term rather than for the DFT:
 
-What the basis has to supply is diffuse functions, not zeta level. Taking the
-free-atom reference in the molecular basis makes the Hirshfeld ratios far less
-basis-sensitive than the density itself, but not insensitive, and the r^3 weight
-of the volume integrals probes the density tail. Over the whole set the residual
-against FHI-aims is a pure systematic offset -- all 528 points deviate in the
-same direction, so the MAE and the bias coincide -- and augmentation shrinks it:
-
-    aug-cc-pVDZ   MAE 0.029 kcal/mol (bias +0.029, i.e. underbinding)
-    def2-TZVP     MAE 0.044 kcal/mol (bias -0.044, i.e. overbinding)
-
-The two bracket the reference from opposite sides, as two incomplete bases
-should either side of the basis-set limit. Hence the aug-cc-pVDZ default: a
-third less residual than def2-TZVP for about 9% more time, despite being only
-double-zeta. Augmentation has to be even-handed across elements, though, since
-the ratio is taken against a promolecule: ma-def2-SVP and ma-def2-TZVP augment
-the heavy atoms only, which shifts weight away from hydrogen and trades error
-out of the pi-stacked systems into the hydrogen-bonded ones for no net gain,
-while def2-SVPD's property-optimized diffuse set is worse than plain def2-SVP.
-
-Note that the diffuse functions make the *DFT* residual worse, not better (PBE
-MAE 0.50 kcal/mol against def2-TZVP's 0.33), because this script computes no
-counterpoise correction and augmentation inflates BSSE. That column is not a
-bridge diagnostic either way; see below.
-
-The integration grid matters much less than it does for the DFT, because the
-same grid integrates the in-molecule and the free-atom volume and its error
-largely cancels in their ratio, so this script defaults to level 1 rather than
-PySCF's 3. It does not survive level 0, though, and how far it survives is
-system-dependent: on an aromatic dimer levels 0 to 4 span 7e-4 kcal/mol, but on
-pentane-pentane, the most hydrogen-rich system in S66, level 0 is 0.029 off
-while level 1 is within 3e-4 of a converged grid. Hydrogen carries the coarsest
-atomic grid, so the aliphatic systems set the requirement. The DFT (PBE) term is
-reported alongside, but at this grid its residual against the all-electron
-reference has a grid component, on top of the basis set and (no counterpoise)
-BSSE -- raise --grid before reading anything into it. None of it is a bridge
-effect.
-
-The SCF convergence threshold can be loosened a long way for the same reason, so
-it defaults to 1e-4 rather than PySCF's 1e-9. Measured over the default subset
-against a tight run, that shifts the MBD energies by 0.0002 kcal/mol on average
-and 0.002 at worst, and takes the run from 220 s to 139 s. Going on to 1e-2
-reaches 123 s but the scatter grows to 0.0035 and 0.012, which is an appreciable
-fraction of the deviation being measured, and being scatter rather than bias it
-does not average out.
+  * ``--basis aug-cc-pvdz``. What matters is diffuse functions rather than zeta
+    level, since the r^3 weight of the volume integrals probes the density tail;
+    an augmented double-zeta set beats an unaugmented triple-zeta one. The
+    augmentation has to be even-handed across elements, because the ratio is
+    taken against a promolecule -- the ma-def2 sets augment the heavy atoms only,
+    which shifts weight off hydrogen and reallocates the error between the
+    hydrogen-bonded and pi-stacked systems rather than removing it.
+  * ``--grid 1``, against PySCF's 3. The same grid integrates the in-molecule and
+    the free-atom volume, so its error largely cancels in the ratio -- but not
+    unconditionally: hydrogen carries the coarsest atomic grid, so the aliphatic
+    systems set the requirement, and level 0 does not meet it.
+  * ``--conv-tol 1e-4``, against PySCF's 1e-9, resting on the same cancellation.
+    Loosening it further turns a negligible shift into scatter comparable with
+    the deviation being measured, and scatter, unlike a bias, does not average
+    out.
 
 Successive points of a curve start from the previous point's converged density,
 which combines with the loose threshold without the error compounding along the
-curve: the deviation from a tight run is flat from the first point, which has no
-guess, to the last.
+curve.
+
+The DFT (PBE) term is reported alongside but is not a bridge diagnostic: with no
+counterpoise correction its residual against the all-electron reference is basis
+set incompleteness plus BSSE plus grid. The augmented default makes it worse
+rather than better, since diffuse functions inflate BSSE. Raise --grid and
+--basis before reading anything into it.
 
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
@@ -98,11 +67,9 @@ Usage:
         [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis aug-cc-pvdz]
 
 Almost all the run time is the DFT itself, so it is worth giving OpenBLAS a
-single thread and leaving the rest to PySCF's OpenMP. Where the two thread pools
-both try to use every core they contend badly: a water dimer took 1.28 s with
-both at four threads against 0.15 s with OPENBLAS_NUM_THREADS=1, and a 17-atom
-dimer 13.4 s against 9.9 s. Restricting OpenMP instead is not a substitute --
-two threads was slower than four at both sizes.
+single thread and leaving the rest to PySCF's OpenMP: where the two thread pools
+both try to use every core they contend badly. Restricting OpenMP instead is not
+a substitute.
 """
 
 import argparse
@@ -316,8 +283,7 @@ def report(rows, seen, args):
     all-electron PBE interaction energy. That keeps the DFT part identical to the
     reference, so the whole difference between the reconstructed and the reference
     MARE is the dispersion term, i.e. the bridge. Adding our own PBE instead would
-    swamp it: at this basis and with no counterpoise correction that term is off by
-    of order 1 kcal/mol, against the ~0.03 the MBD term is being judged on.
+    swamp it, that term being uncorrected for BSSE and in a finite basis.
     """
     mbd_our = np.array([r['mbd_our'] for r in rows])
     mbd_paper = np.array([r['mbd_paper'] for r in rows])

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -13,13 +13,16 @@ point, with the FHI-aims MBD energies of
 
 whose processed results are published on figshare. Because FHI-aims shares no
 code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
-term is an independent cross-code validation of the bridge; it currently agrees
-to ~0.006 kcal/mol MAE in the default def2-SVP basis (~0.003 in def2-TZVP).
-The MBD term is only weakly basis-dependent, because the free-atom reference is
-taken in the same basis and cancels its incompleteness, so the cheap basis is
-enough to validate the bridge. The DFT (PBE) term is also reported: its residual
-against the all-electron reference is a basis-set (and, without counterpoise,
-BSSE) effect, not a bridge effect.
+term is an independent cross-code validation of the bridge.
+
+Use a basis of at least triple-zeta quality. Taking the free-atom reference in
+the molecular basis makes the Hirshfeld ratios far less basis-sensitive than the
+density itself, but not insensitive: over the default subset def2-SVP gives an
+MBD MAE of 0.037 kcal/mol against def2-TZVP's 0.018, and the gap is concentrated
+in the systems with pi systems (0.11 for pyridine-ethene, 0.09 for
+uracil-ethyne, against 0.005-0.009 for the small hydrogen-bonded ones). The DFT
+(PBE) term is also reported: its residual against the all-electron reference is
+a basis-set (and, without counterpoise, BSSE) effect, not a bridge effect.
 
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
@@ -29,7 +32,7 @@ Data (downloaded/located, not shipped):
 
 Usage:
     python pyscf_s66x8_figshare_check.py --vdwsets /path/to/vdwsets/clone \\
-        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-svp]
+        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-tzvp]
 """
 
 import argparse
@@ -130,7 +133,7 @@ def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--vdwsets', required=True, help='path to a vdwsets checkout')
     p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
-    p.add_argument('--basis', default='def2-svp')
+    p.add_argument('--basis', default='def2-tzvp')
     p.add_argument('--xc', default='PBE')
     p.add_argument(
         '--idx',

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -31,8 +31,16 @@ Data (downloaded/located, not shipped):
     https://github.com/azag0/vdwsets  (git clone it and pass --vdwsets)
 
 Usage:
-    python pyscf_s66x8_figshare_check.py --vdwsets /path/to/vdwsets/clone \\
+    OPENBLAS_NUM_THREADS=1 python pyscf_s66x8_figshare_check.py \\
+        --vdwsets /path/to/vdwsets/clone \\
         [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-tzvp]
+
+Almost all the run time is the DFT itself, so it is worth giving OpenBLAS a
+single thread and leaving the rest to PySCF's OpenMP. Where the two thread pools
+both try to use every core they contend badly: a water dimer took 1.28 s with
+both at four threads against 0.15 s with OPENBLAS_NUM_THREADS=1, and a 17-atom
+dimer 13.4 s against 9.9 s. Restricting OpenMP instead is not a substitute --
+two threads was slower than four at both sizes.
 """
 
 import argparse

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -33,12 +33,18 @@ against the all-electron reference is dominated by grid error, on top of the
 basis set and (no counterpoise) BSSE -- raise --grid before reading anything
 into it. None of it is a bridge effect.
 
-The SCF convergence threshold can be loosened a long way for the same reason.
-Over the default subset, --conv-tol 1e-4 moves the MBD energies by ~5e-5
-kcal/mol while taking the run from 220 s to 139 s; 1e-2 takes it to 123 s but
-the energies then scatter by 0.0035 kcal/mol on average and 0.012 at worst,
-which is an appreciable fraction of the deviation being measured, and it is
-scatter rather than a bias, so it does not average out.
+The SCF convergence threshold can be loosened a long way for the same reason, so
+it defaults to 1e-4 rather than PySCF's 1e-9. Measured over the default subset
+against a tight run, that shifts the MBD energies by 0.0002 kcal/mol on average
+and 0.002 at worst, and takes the run from 220 s to 139 s. Going on to 1e-2
+reaches 123 s but the scatter grows to 0.0035 and 0.012, which is an appreciable
+fraction of the deviation being measured, and being scatter rather than bias it
+does not average out.
+
+Successive points of a curve start from the previous point's converged density,
+which combines with the loose threshold without the error compounding along the
+curve: the deviation from a tight run is flat from the first point, which has no
+guess, to the last.
 
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
@@ -152,8 +158,11 @@ def our_energies(species, coords, basis, xc, grid, conv_tol, dm0=None):
     ``dm0`` is an initial guess, meant to be the converged density of the previous
     point of a dissociation curve. The monomers are rigid along one, so successive
     complexes differ only in their separation and the previous density is a good
-    starting point. It cannot change the converged result and so is deliberately
-    not part of the cache key.
+    starting point. At a tight threshold it cannot change the converged result; at
+    a loose one it can shift where the SCF stops, but only within that threshold's
+    own noise, and measurably without compounding along the curve. Either way it
+    is not part of the cache key, which identifies a geometry rather than a path
+    taken to it.
     """
     key = (basis, xc, grid, conv_tol, tuple(species), tuple(map(tuple, coords)))
     if key in _ENERGIES:
@@ -193,8 +202,9 @@ def main(argv=None):
     p.add_argument(
         '--conv-tol',
         type=float,
-        default=1e-9,
-        help="SCF convergence threshold (PySCF's own default is 1e-9)",
+        default=1e-4,
+        help='SCF convergence threshold (default 1e-4: see the module docstring; '
+        "PySCF's own default is 1e-9)",
     )
     p.add_argument(
         '--idx',

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -15,6 +15,27 @@ whose processed results are published on figshare. Because FHI-aims shares no
 code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
 term is an independent cross-code validation of the bridge.
 
+Besides the MBD term itself the summary reports what that deviation is worth on
+the benchmark the method is actually judged by, as a MARE against the CCSD(T)/CBS
+S66x8 reference energies. The reconstructed total puts our MBD term on top of the
+*reference's* own all-electron PBE interaction energy rather than ours, so the DFT
+part is identical in both totals and the whole gap between the reconstructed and
+the reference MARE is the bridge. Using our PBE would drown it: uncorrected for
+BSSE and in a finite basis that term is off by of order 1 kcal/mol, against the
+~0.03 the MBD term is being judged on. Over the full set (--all) the reference
+row reproduces the published MAE 0.318 / MARE 10.1%, which doubles as a check on
+the surrounding machinery, and the reconstructed MARE is 10.1% in aug-cc-pVDZ,
+10.6% in def2-TZVP and 11.4% in def2-SVP, against 65.6% with no dispersion.
+
+Both are also broken down by separation, which is where the two ways of being
+wrong separate. The MBD deviation is a nearly pure systematic offset -- in every
+basis tried the MAE equals the bias to four decimals and 96-99% of points deviate
+in the same direction -- so it partly cancels against the reference's own error at
+some separations and compounds at others. def2-SVP is the sharpest illustration:
+it scores better than the reference at the most compressed geometry (22.4% against
+26.6%) and worst of all at the longest (8.4% against 4.5%). Ranking bases on the
+short separations alone orders them backwards.
+
 What the basis has to supply is diffuse functions, not zeta level. Taking the
 free-atom reference in the molecular basis makes the Hirshfeld ratios far less
 basis-sensitive than the density itself, but not insensitive, and the r^3 weight
@@ -284,12 +305,36 @@ def main(argv=None):
     if not rows:
         print('no matching systems found', file=sys.stderr)
         return 1
-    dmbd = np.array([r['mbd_our'] - r['mbd_paper'] for r in rows])
+    report(rows, seen, args)
+    return 0
+
+
+def report(rows, seen, args):
+    """Print the summary: MBD deviation, reconstructed MARE, and both by separation.
+
+    The reconstructed total energy is our MBD term on top of the *reference's* own
+    all-electron PBE interaction energy. That keeps the DFT part identical to the
+    reference, so the whole difference between the reconstructed and the reference
+    MARE is the dispersion term, i.e. the bridge. Adding our own PBE instead would
+    swamp it: at this basis and with no counterpoise correction that term is off by
+    of order 1 kcal/mol, against the ~0.03 the MBD term is being judged on.
+    """
+    mbd_our = np.array([r['mbd_our'] for r in rows])
+    mbd_paper = np.array([r['mbd_paper'] for r in rows])
+    pbe_paper = np.array([r['pbe_paper'] for r in rows])
     dpbe = np.array([r['pbe_our'] - r['pbe_paper'] for r in rows])
+    ref = np.array([r['ref'] for r in rows])
+    scales = np.array([r['scale'] for r in rows])
+    dmbd = mbd_our - mbd_paper
+
+    def mare(total, sel=slice(None)):
+        return 100 * np.mean(np.abs((total[sel] - ref[sel]) / ref[sel]))
+
     print(f'\n{len(rows)} points over systems {sorted(seen)}')
     print(
         f'MBD  (ours vs FHI-aims):  MAE {np.abs(dmbd).mean():.4f}  '
-        f'max|Δ| {np.abs(dmbd).max():.4f}  bias {dmbd.mean():+.4f} kcal/mol'
+        f'max|Δ| {np.abs(dmbd).max():.4f}  bias {dmbd.mean():+.4f} kcal/mol  '
+        f'({100 * np.mean(mbd_our / mbd_paper - 1):+.2f}% mean relative)'
     )
     print(
         f'PBE  (our {args.basis}, grid {args.grid}, conv {args.conv_tol:g}, no CP, '
@@ -297,7 +342,29 @@ def main(argv=None):
         f'MAE {np.abs(dpbe).mean():.4f}  bias {dpbe.mean():+.4f} kcal/mol  '
         f'(basis set + BSSE + grid, not the bridge)'
     )
-    return 0
+
+    # against the CCSD(T)/CBS benchmark, with the reference's PBE in both totals
+    print(
+        f'\nvs CCSD(T)/CBS, reference PBE + MBD:  '
+        f'reconstructed (our MBD) MARE {mare(pbe_paper + mbd_our):.1f}%   '
+        f'reference MARE {mare(pbe_paper + mbd_paper):.1f}%   '
+        f'no dispersion {mare(pbe_paper):.1f}%'
+    )
+
+    print('\nby separation:')
+    print(
+        f'{"scale":>7} {"n":>5} {"MBD rel dev":>13} '
+        f'{"MARE recon":>12} {"MARE ref":>10} {"|E| ref":>9}'
+    )
+    for s in sorted(set(scales)):
+        m = scales == s
+        print(
+            f'{s:>7.2f} {m.sum():>5d} '
+            f'{100 * np.mean(mbd_our[m] / mbd_paper[m] - 1):>+12.2f}% '
+            f'{mare(pbe_paper + mbd_our, m):>11.1f}% '
+            f'{mare(pbe_paper + mbd_paper, m):>9.1f}% '
+            f'{np.mean(np.abs(ref[m])):>9.3f}'
+        )
 
 
 if __name__ == '__main__':

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -15,12 +15,29 @@ whose processed results are published on figshare. Because FHI-aims shares no
 code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
 term is an independent cross-code validation of the bridge.
 
-Use a basis of at least triple-zeta quality. Taking the free-atom reference in
-the molecular basis makes the Hirshfeld ratios far less basis-sensitive than the
-density itself, but not insensitive: over the default subset def2-SVP gives an
-MBD MAE of 0.037 kcal/mol against def2-TZVP's 0.018, and the gap is concentrated
-in the systems with pi systems (0.11 for pyridine-ethene, 0.09 for
-uracil-ethyne, against 0.005-0.009 for the small hydrogen-bonded ones).
+What the basis has to supply is diffuse functions, not zeta level. Taking the
+free-atom reference in the molecular basis makes the Hirshfeld ratios far less
+basis-sensitive than the density itself, but not insensitive, and the r^3 weight
+of the volume integrals probes the density tail. Over the whole set the residual
+against FHI-aims is a pure systematic offset -- all 528 points deviate in the
+same direction, so the MAE and the bias coincide -- and augmentation shrinks it:
+
+    aug-cc-pVDZ   MAE 0.029 kcal/mol (bias +0.029, i.e. underbinding)
+    def2-TZVP     MAE 0.044 kcal/mol (bias -0.044, i.e. overbinding)
+
+The two bracket the reference from opposite sides, as two incomplete bases
+should either side of the basis-set limit. Hence the aug-cc-pVDZ default: a
+third less residual than def2-TZVP for about 9% more time, despite being only
+double-zeta. Augmentation has to be even-handed across elements, though, since
+the ratio is taken against a promolecule: ma-def2-SVP and ma-def2-TZVP augment
+the heavy atoms only, which shifts weight away from hydrogen and trades error
+out of the pi-stacked systems into the hydrogen-bonded ones for no net gain,
+while def2-SVPD's property-optimized diffuse set is worse than plain def2-SVP.
+
+Note that the diffuse functions make the *DFT* residual worse, not better (PBE
+MAE 0.50 kcal/mol against def2-TZVP's 0.33), because this script computes no
+counterpoise correction and augmentation inflates BSSE. That column is not a
+bridge diagnostic either way; see below.
 
 The integration grid matters much less than it does for the DFT, because the
 same grid integrates the in-molecule and the free-atom volume and its error
@@ -57,7 +74,7 @@ Data (downloaded/located, not shipped):
 Usage:
     OPENBLAS_NUM_THREADS=1 python pyscf_s66x8_figshare_check.py \\
         --vdwsets /path/to/vdwsets/clone \\
-        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-tzvp]
+        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis aug-cc-pvdz]
 
 Almost all the run time is the DFT itself, so it is worth giving OpenBLAS a
 single thread and leaving the rest to PySCF's OpenMP. Where the two thread pools
@@ -192,7 +209,7 @@ def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--vdwsets', required=True, help='path to a vdwsets checkout')
     p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
-    p.add_argument('--basis', default='def2-tzvp')
+    p.add_argument('--basis', default='aug-cc-pvdz')
     p.add_argument('--xc', default='PBE')
     p.add_argument(
         '--grid',

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -20,9 +20,18 @@ the molecular basis makes the Hirshfeld ratios far less basis-sensitive than the
 density itself, but not insensitive: over the default subset def2-SVP gives an
 MBD MAE of 0.037 kcal/mol against def2-TZVP's 0.018, and the gap is concentrated
 in the systems with pi systems (0.11 for pyridine-ethene, 0.09 for
-uracil-ethyne, against 0.005-0.009 for the small hydrogen-bonded ones). The DFT
-(PBE) term is also reported: its residual against the all-electron reference is
-a basis-set (and, without counterpoise, BSSE) effect, not a bridge effect.
+uracil-ethyne, against 0.005-0.009 for the small hydrogen-bonded ones).
+
+The integration grid, by contrast, hardly matters, because the same grid
+integrates the in-molecule and the free-atom volume and its error largely
+cancels in their ratio. Between PySCF grid levels 0 and 4 the MBD interaction
+energy of a 17-atom dimer moves by 7e-4 kcal/mol, two orders of magnitude below
+the deviation being measured, while the SCF energy moves by 16 kcal/mol. This
+script only validates the MBD term, so it defaults to level 0 and takes the
+speedup. The DFT (PBE) term is reported alongside, but at this grid its residual
+against the all-electron reference is dominated by grid error, on top of the
+basis set and (no counterpoise) BSSE -- raise --grid before reading anything
+into it. None of it is a bridge effect.
 
 Data (downloaded/located, not shipped):
   * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
@@ -124,14 +133,14 @@ def load_paper(h5_path):
 _ENERGIES = {}
 
 
-def our_energies(species, coords, basis, xc):
+def our_energies(species, coords, basis, xc, grid):
     """Return (SCF energy, MBD energy) for one fragment, memoized on its geometry.
 
     The two monomers of a system are taken at its equilibrium separation whatever
     the separation of the complex, so they are the same fragment at all eight
     points of a dissociation curve and only need computing once.
     """
-    key = (basis, xc, tuple(species), tuple(map(tuple, coords)))
+    key = (basis, xc, grid, tuple(species), tuple(map(tuple, coords)))
     if key in _ENERGIES:
         return _ENERGIES[key]
 
@@ -146,6 +155,7 @@ def our_energies(species, coords, basis, xc):
         verbose=0,
     )
     mf = dft.RKS(mol, xc=xc).density_fit()
+    mf.grids.level = grid
     mf.kernel()
     _ENERGIES[key] = (mf.e_tot, mbd_energy(mf, beta=MBD_BETA))
     return _ENERGIES[key]
@@ -157,6 +167,13 @@ def main(argv=None):
     p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
     p.add_argument('--basis', default='def2-tzvp')
     p.add_argument('--xc', default='PBE')
+    p.add_argument(
+        '--grid',
+        type=int,
+        default=0,
+        help='PySCF grid level (default 0: enough for MBD, see the module '
+        'docstring, but too coarse for the DFT energies)',
+    )
     p.add_argument(
         '--idx',
         type=int,
@@ -176,7 +193,10 @@ def main(argv=None):
         key = (_norm(label), float(scale))
         if key not in mbd_ref:
             continue
-        e = {name: our_energies(*g, args.basis, args.xc) for name, g in frags.items()}
+        e = {
+            name: our_energies(*g, args.basis, args.xc, args.grid)
+            for name, g in frags.items()
+        }
         pbe_int = (e['complex'][0] - e['fragment-1'][0] - e['fragment-2'][0]) * AU2KCAL
         mbd_int = (e['complex'][1] - e['fragment-1'][1] - e['fragment-2'][1]) * AU2KCAL
         rows.append(
@@ -211,9 +231,9 @@ def main(argv=None):
         f'max|Δ| {np.abs(dmbd).max():.4f}  bias {dmbd.mean():+.4f} kcal/mol'
     )
     print(
-        f'PBE  (our {args.basis}, no CP, vs all-electron):  '
+        f'PBE  (our {args.basis}, grid {args.grid}, no CP, vs all-electron):  '
         f'MAE {np.abs(dpbe).mean():.4f}  bias {dpbe.mean():+.4f} kcal/mol  '
-        f'(basis-set + BSSE, not the bridge)'
+        f'(basis set + BSSE + grid, not the bridge)'
     )
     return 0
 

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Validate the pymbd.pyscf bridge against published all-electron MBD data.
+
+For a subset of S66x8 dimers this recomputes the MBD@rsSCS interaction energy
+with the PySCF -> pyMBD bridge (:mod:`pymbd.pyscf`) and compares it, point by
+point, with the FHI-aims MBD energies of
+
+    Hermann & Tkatchenko, "Electronic exchange and correlation in van der Waals
+    systems", J. Chem. Theory Comput. (2018); doi:10.1021/acs.jctc.7b01172,
+
+whose processed results are published on figshare. Because FHI-aims shares no
+code, basis, or Hirshfeld implementation with PySCF/pyMBD, agreement on the MBD
+term is an independent cross-code validation of the bridge. The DFT (PBE) term
+is also reported: its residual against the all-electron reference is a
+basis-set effect, not a bridge effect.
+
+Data (downloaded/located, not shipped):
+  * figshare all-data.h5  https://ndownloader.figshare.com/files/9775933
+    (article 5117167, "dft-vdw-range Data")
+  * geometries + labels from the vdwsets data files (read directly, no import)
+    https://github.com/azag0/vdwsets  (git clone it and pass --vdwsets)
+
+Usage:
+    python pyscf_s66x8_figshare_check.py --vdwsets /path/to/vdwsets/clone \\
+        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] [--basis def2-tzvp]
+"""
+
+import argparse
+import csv
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+
+AU2KCAL = 627.509474
+H5_URL = 'https://ndownloader.figshare.com/files/9775933'
+# MBD@rsSCS for PBE (matches the reference calculations)
+MBD_A, MBD_BETA = 6.0, 0.83
+
+
+def _norm(label):
+    return re.sub(r'\s+', ' ', label).strip().lower()
+
+
+def read_xyz(path):
+    species, coords = [], []
+    with open(path) as f:
+        n = int(f.readline())
+        f.readline()  # comment
+        for _ in range(n):
+            el, x, y, z = f.readline().split()[:4]
+            species.append(el)
+            coords.append([float(x), float(y), float(z)])
+    return species, coords
+
+
+def load_geometries(vdwsets_root, idx_filter):
+    """Yield (idx, label, scale, fragments) from a vdwsets checkout's data files.
+
+    Reproduces the S66x8 filename convention of vdwsets.get_s66x8 without
+    importing the package (which needs pkg_resources). ``fragments`` maps
+    'complex'/'fragment-1'/'fragment-2' to (species, coords).
+    """
+    data = Path(vdwsets_root) / 'vdwsets' / 'data' / 's66x8'
+    with open(data / 'energies.csv') as f:
+        rows = list(csv.DictReader(f))
+    for row in rows:
+        idx, label, scale = int(row['idx']), row['label'], float(row['scale'])
+        if idx_filter is not None and idx not in idx_filter:
+            continue
+        file_lbl = label.replace(' ', '-').lower()
+        frags = {}
+        for j, frag in enumerate(['complex', 'fragment', 'fragment']):
+            scale_lbl = scale if frag == 'complex' else 1.0
+            path = (
+                data / 'geoms' / f'{idx:02}-{scale_lbl:.2f}_{file_lbl}_{frag}_{j}.xyz'
+            )
+            key = 'complex' if frag == 'complex' else f'fragment-{j}'
+            frags[key] = read_xyz(path)
+        yield idx, label, scale, frags
+
+
+def ensure_h5(path):
+    if not path.exists():
+        print(f'downloading all-data.h5 -> {path} ...', flush=True)
+        urllib.request.urlretrieve(H5_URL, path)
+    return path
+
+
+def load_paper(h5_path):
+    import pandas as pd
+
+    with pd.HDFStore(str(h5_path), 'r') as store:
+        mbd = store['mbd'].xs(('S66x8', MBD_A, MBD_BETA), level=('name', 'a', 'beta'))[
+            'ene'
+        ]
+        scf = store['scf'].xs(('S66x8', 'pbe', False), level=('name', 'xc', 'cp'))
+    pbe = {(_norm(s), float(d)): v for (s, d), v in scf['ene'].items()}
+    ref = {(_norm(s), float(d)): v for (s, d), v in scf['ref'].items()}
+    mbd = {(_norm(s), float(d)): v for (s, d), v in mbd.items()}
+    return pbe, mbd, ref
+
+
+def our_energies(species, coords, basis, xc):
+    from pyscf import dft, gto
+
+    from pymbd.pyscf import mbd_energy
+
+    mol = gto.M(
+        atom=[[s, tuple(c)] for s, c in zip(species, coords)],
+        basis=basis,
+        unit='Angstrom',
+        verbose=0,
+    )
+    mf = dft.RKS(mol, xc=xc).density_fit()
+    mf.kernel()
+    return mf.e_tot, mbd_energy(mf, beta=MBD_BETA)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--vdwsets', required=True, help='path to a vdwsets checkout')
+    p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
+    p.add_argument('--basis', default='def2-tzvp')
+    p.add_argument('--xc', default='PBE')
+    p.add_argument(
+        '--idx',
+        type=int,
+        nargs='+',
+        default=[1, 2, 8, 32, 33, 51, 59, 60],
+        help='S66 system indices to run (default: a small E/D/M-spanning subset)',
+    )
+    p.add_argument('--all', action='store_true', help='run all 66 systems')
+    args = p.parse_args(argv)
+
+    pbe_ref, mbd_ref, ccsdt = load_paper(ensure_h5(Path(args.h5)))
+    idx_filter = None if args.all else set(args.idx)
+
+    rows = []
+    seen = set()
+    for idx, label, scale, frags in load_geometries(args.vdwsets, idx_filter):
+        key = (_norm(label), float(scale))
+        if key not in mbd_ref:
+            continue
+        e = {name: our_energies(*g, args.basis, args.xc) for name, g in frags.items()}
+        pbe_int = (e['complex'][0] - e['fragment-1'][0] - e['fragment-2'][0]) * AU2KCAL
+        mbd_int = (e['complex'][1] - e['fragment-1'][1] - e['fragment-2'][1]) * AU2KCAL
+        rows.append(
+            {
+                'idx': idx,
+                'label': label,
+                'scale': float(scale),
+                'mbd_our': mbd_int,
+                'mbd_paper': mbd_ref[key],
+                'pbe_our': pbe_int,
+                'pbe_paper': pbe_ref[key],
+                'ref': ccsdt[key],
+            }
+        )
+        seen.add(idx)
+        r = rows[-1]
+        print(
+            f'{idx:2d} {label:28.28s} {scale:4.2f} | '
+            f'MBD our {r["mbd_our"]:7.3f}  paper {r["mbd_paper"]:7.3f}  '
+            f'Δ {r["mbd_our"] - r["mbd_paper"]:+.3f}',
+            flush=True,
+        )
+
+    if not rows:
+        print('no matching systems found', file=sys.stderr)
+        return 1
+    dmbd = np.array([r['mbd_our'] - r['mbd_paper'] for r in rows])
+    dpbe = np.array([r['pbe_our'] - r['pbe_paper'] for r in rows])
+    print(f'\n{len(rows)} points over systems {sorted(seen)}')
+    print(
+        f'MBD  (ours vs FHI-aims):  MAE {np.abs(dmbd).mean():.4f}  '
+        f'max|Δ| {np.abs(dmbd).max():.4f}  bias {dmbd.mean():+.4f} kcal/mol'
+    )
+    print(
+        f'PBE  (our {args.basis}, no CP, vs all-electron):  '
+        f'MAE {np.abs(dpbe).mean():.4f}  bias {dpbe.mean():+.4f} kcal/mol  '
+        f'(basis-set + BSSE, not the bridge)'
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,6 +10,12 @@ Pure-Python implementation
 
     Can be imported directly as :py:data:`pymbd.ang`.
 
+PySCF bridge
+------------
+
+.. automodule:: pymbd.pyscf
+   :members: hirshfeld_volume_ratios, mbd_energy
+
 Fortran bindings
 ----------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,6 +55,7 @@ autodoc_mock_imports = [
     'scipy',
     'pymbd._libmbd',
     'mpi4py',
+    'pyscf',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ quote-style = "preserve"
 branch = true
 source = ["pymbd"]
 parallel = true
-omit = ["*/pymbd/tensorflow.py", "*/pymbd/benchmark.py"]
+omit = ["*/pymbd/tensorflow.py", "*/pymbd/benchmark.py", "*/pymbd/pyscf.py"]
 
 # Map the installed (non-editable) package back onto the source tree so the
 # combined report and coverage.xml use src/pymbd/... paths regardless of how

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ numpy = ">=1.20"
 cffi = ">=1"
 pytest = { version = "*", optional = true }
 mpi4py = { version = "^3 || ^4", optional = true }
-pyscf = { version = ">=2.1", optional = true, markers = "platform_system != 'Windows'" }
+pyscf = { version = ">=2.1", optional = true }
 
 [tool.poetry.extras]
 mpi = ["mpi4py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,12 @@ numpy = ">=1.20"
 cffi = ">=1"
 pytest = { version = "*", optional = true }
 mpi4py = { version = "^3 || ^4", optional = true }
+pyscf = { version = ">=2.1", optional = true, markers = "platform_system != 'Windows'" }
 
 [tool.poetry.extras]
 mpi = ["mpi4py"]
 test = ["pytest"]
+pyscf = ["pyscf"]
 
 [tool.poetry.dev-dependencies]
 ruff = ">=0.10"

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -46,6 +46,12 @@ __all__ = ['hirshfeld_volume_ratios', 'mbd_energy', 'AtomSphAverageRKS']
 # MBD@rsSCS range-separation parameter beta per exchange-correlation functional.
 _BETA_RSSCS = {'pbe': 0.83, 'pbe0': 0.85, 'hse': 0.85}
 
+# Grid is processed in blocks: the promolecule AO array would otherwise be
+# ngrid x nao of the (large) free-atom basis, which reaches several GB for a
+# few dozen atoms in aug-cc-pVQZ.
+_GRID_BLKSIZE = 8192
+_AO_BLOCK_BYTES = 128 << 20
+
 
 class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
     """Spherically averaged neutral free-atom solver with a Kohn--Sham potential.
@@ -66,15 +72,17 @@ class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
 
 
 @lru_cache(maxsize=None)
-def _free_atom(symb, basis, xc):
-    """Spherically averaged free-atom ``(Mole, density matrix)`` for one element.
+def _free_atom_dm(symb, basis, xc):
+    """Spherically averaged free-atom density matrix for one element.
 
     Cached per ``(element, basis, xc)``, so each atomic SCF runs once per process.
-    The Mole is placed at the origin; callers evaluate it elsewhere by shifting
-    the grid. The one-electron atom (hydrogen) is kept as the self-consistent DFT
-    density (diffuse, self-interaction and all), which is the MBD/TS convention.
-    ``spin`` is set to the electron-count parity only to satisfy the Mole build;
-    the spherical-average solver fixes the occupation by fractional filling.
+    Since it only depends on the element and the basis, the result is expressed in
+    exactly the AO ordering of that element's block of the promolecule (see
+    :func:`_promolecule_mole`), where it is used. The one-electron atom (hydrogen)
+    is kept as the self-consistent DFT density (diffuse, self-interaction and
+    all), which is the MBD/TS convention. ``spin`` is set to the electron-count
+    parity only to satisfy the Mole build; the spherical-average solver fixes the
+    occupation by fractional filling.
     """
     mol = gto.M(
         atom=[[symb, (0.0, 0.0, 0.0)]],
@@ -84,19 +92,24 @@ def _free_atom(symb, basis, xc):
     )
     mf = AtomSphAverageRKS(mol, xc=xc)
     mf.kernel()
-    return mol, mf.make_rdm1()
+    return mf.make_rdm1()
 
 
-def _promolecule_densities(mol, coords, xc, free_atom_basis):
-    """Per-atom free-atom densities on ``coords`` and their sum (the promolecule)."""
-    rho_free = np.zeros((mol.natm, len(coords)))
-    for ia in range(mol.natm):
-        atm, dm = _free_atom(mol.atom_symbol(ia), free_atom_basis, xc)
-        # atm is centered at the origin; shift the grid rather than rebuild a Mole
-        ao = dft.numint.eval_ao(atm, coords - mol.atom_coord(ia))
-        rho_free[ia] = dft.numint.eval_rho(atm, ao, dm)
-    rho_free = np.clip(rho_free, 0, None)
-    return rho_free, rho_free.sum(axis=0)
+def _promolecule_mole(mol, free_atom_basis):
+    """Mole with the free-atom basis on every atom of ``mol`` (the promolecule).
+
+    Only ever used to evaluate basis functions on a grid, never for an SCF, so
+    ``spin`` just has to match the parity of the neutral-atom electron count.
+    """
+    return gto.M(
+        atom=[
+            [mol.atom_symbol(ia), tuple(mol.atom_coord(ia))] for ia in range(mol.natm)
+        ],
+        basis=free_atom_basis,
+        unit='Bohr',
+        spin=sum(gto.charge(mol.atom_symbol(ia)) for ia in range(mol.natm)) % 2,
+        verbose=0,
+    )
 
 
 def hirshfeld_volume_ratios(
@@ -129,32 +142,59 @@ def hirshfeld_volume_ratios(
             'MBD Hirshfeld partitioning requires a KS-DFT mean-field; got one '
             'with no exchange-correlation functional (Hartree-Fock)'
         )
+    ghosts = [ia for ia in range(mol.natm) if mol.atom_charge(ia) == 0]
+    if ghosts:
+        raise ValueError(
+            'Hirshfeld partitioning is undefined for ghost atoms (no nucleus, '
+            f'hence no free-atom reference); found at atom indices {ghosts}. '
+            'Evaluate the dispersion on the ghost-free fragments: unlike the '
+            'DFT interaction energy, the MBD term needs no counterpoise.'
+        )
     grids = getattr(mf, 'grids', None)
     if grids is None or grids.coords is None:
         grids = dft.gen_grid.Grids(mol)
         grids.level = grid_level
         grids.build()
-    coords, weights = grids.coords, grids.weights
-
     dm = mf.make_rdm1()
     if np.ndim(dm) == 3:  # unrestricted -> total density
         dm = dm[0] + dm[1]
-    rho = dft.numint.eval_rho(mol, dft.numint.eval_ao(mol, coords), dm)
 
-    rho_free, rho_promol = _promolecule_densities(
-        mol, coords, free_atom_xc, free_atom_basis
-    )
-    rho_promol = np.where(rho_promol > 1e-30, rho_promol, 1e-30)
-
+    # All free-atom densities come from one basis (the promolecule Mole) evaluated
+    # in a single pass over the grid: the free-atom density matrices are
+    # block-diagonal in it, so atom A's density is the contraction of A's own AO
+    # block with its cached density matrix. Grid blocking keeps the AO array
+    # bounded and lets the integrals be accumulated on the fly, so neither the
+    # (natm, ngrid) promolecule matrix nor a full AO array is ever materialized.
+    promol = _promolecule_mole(mol, free_atom_basis)
+    aoslices = promol.aoslice_by_atom()
+    free_dms = [
+        _free_atom_dm(mol.atom_symbol(ia), free_atom_basis, free_atom_xc)
+        for ia in range(mol.natm)
+    ]
     atom_coords = mol.atom_coords()
-    ratios = np.empty(mol.natm)
-    for ia in range(mol.natm):
-        r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
-        w = rho_free[ia] / rho_promol
-        v_eff = np.einsum('g,g,g,g->', weights, w, r3, rho)
-        v_free = np.einsum('g,g,g->', weights, r3, rho_free[ia])
-        ratios[ia] = v_eff / v_free
-    return ratios
+    blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * promol.nao)))
+
+    v_eff = np.zeros(mol.natm)
+    v_free = np.zeros(mol.natm)
+    for i0 in range(0, len(grids.coords), blksize):
+        coords = grids.coords[i0 : i0 + blksize]
+        weights = grids.weights[i0 : i0 + blksize]
+        ao_free = dft.numint.eval_ao(promol, coords)
+        rho_free = np.empty((mol.natm, len(coords)))
+        for ia in range(mol.natm):
+            _, _, p0, p1 = aoslices[ia]
+            ao_a = ao_free[:, p0:p1]
+            rho_free[ia] = np.einsum('gi,ij,gj->g', ao_a, free_dms[ia], ao_a)
+        np.clip(rho_free, 0, None, out=rho_free)
+        rho_promol = rho_free.sum(axis=0)
+        np.maximum(rho_promol, 1e-30, out=rho_promol)
+        rho = dft.numint.eval_rho(mol, dft.numint.eval_ao(mol, coords), dm)
+        for ia in range(mol.natm):
+            r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
+            w = rho_free[ia] / rho_promol  # Hirshfeld weight
+            v_eff[ia] += np.einsum('g,g,g,g->', weights, w, r3, rho)
+            v_free[ia] += np.einsum('g,g,g->', weights, r3, rho_free[ia])
+    return v_eff / v_free
 
 
 def mbd_energy(

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -28,8 +28,11 @@ is also present in the molecular density, so well-separated atoms come out at
 exactly 1 in any basis. For a one-electron atom (hydrogen) the reference is the
 diffuse, self-consistent DFT density, matching the FHI-aims/libMBD convention.
 Benchmarking against independent all-electron FHI-aims MBD energies confirms these
-choices: MBD interaction energies agree to ~0.003 kcal/mol (against ~0.016 with a
-fixed aug-cc-pVQZ reference). MBD is only meaningful on top of a
+choices: over the full S66x8 set (528 points) the MBD interaction energies agree to
+0.03 kcal/mol MAE in aug-cc-pVDZ and 0.04 in def2-TZVP, the residual in each case
+being a systematic basis-set offset rather than scatter, and on the subset used to
+compare free-atom references the molecular-basis choice was about five times more
+accurate than a fixed aug-cc-pVQZ one. MBD is only meaningful on top of a
 (semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
 
 Requires PySCF (``pip install pymbd[pyscf]``)::

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -182,6 +182,12 @@ def hirshfeld_volume_ratios(mf):
             # they would occupy are zero and can be skipped. Contracting as a
             # matrix product (the way eval_rho does internally) goes through
             # BLAS, ~10x faster than the equivalent three-operand einsum.
+            #
+            # The loop is what exploits that sparsity, so vectorizing it over
+            # atoms costs more than it saves: assembling the block-diagonal
+            # matrix and segment-summing (ao @ D) * ao with add.reduceat, or
+            # gathering same-element blocks into one batched product, both
+            # measured ~1.8x slower than this.
             rho_free[i] = np.einsum('gi,gi->g', ao_a.dot(free_dms[i]), ao_a)
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -184,7 +184,10 @@ def hirshfeld_volume_ratios(
         for ia in range(mol.natm):
             _, _, p0, p1 = aoslices[ia]
             ao_a = ao_free[:, p0:p1]
-            rho_free[ia] = np.einsum('gi,ij,gj->g', ao_a, free_dms[ia], ao_a)
+            # contract via a matrix product, as eval_rho does internally: going
+            # through BLAS is ~10x faster than a three-operand einsum here, and
+            # the block structure avoids the (much larger) dense nao x nao product
+            rho_free[ia] = np.einsum('gi,gi->g', ao_a.dot(free_dms[ia]), ao_a)
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -32,7 +32,15 @@ choices: MBD interaction energies agree to ~0.003 kcal/mol (against ~0.016 with 
 fixed aug-cc-pVQZ reference). MBD is only meaningful on top of a
 (semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
 
-Requires PySCF (``pip install pymbd[pyscf]``).
+Requires PySCF (``pip install pymbd[pyscf]``)::
+
+    from pyscf import dft, gto
+
+    from pymbd.pyscf import mbd_energy
+
+    mol = gto.M(atom='He 0 0 0; He 0 0 3', basis='def2-tzvp')
+    mf = dft.RKS(mol, xc='PBE').run()
+    ene = mbd_energy(mf)  # beta is taken from the functional
 """
 
 from functools import lru_cache
@@ -49,9 +57,8 @@ __all__ = ['hirshfeld_volume_ratios', 'mbd_energy', 'AtomSphAverageRKS']
 # MBD@rsSCS range-separation parameter beta per exchange-correlation functional.
 _BETA_RSSCS = {'pbe': 0.83, 'pbe0': 0.85, 'hse': 0.85}
 
-# Grid is processed in blocks: the promolecule AO array would otherwise be
-# ngrid x nao of the (large) free-atom basis, which reaches several GB for a
-# few dozen atoms in aug-cc-pVQZ.
+# Grid is processed in blocks: a whole-grid AO array is ngrid x nao, which runs
+# into several GB for a few dozen atoms in a triple-zeta or larger basis.
 _GRID_BLKSIZE = 8192
 _AO_BLOCK_BYTES = 128 << 20
 
@@ -91,13 +98,13 @@ def _free_atom_dm(symb, basis, xc):
     """Spherically averaged free-atom density matrix for one element.
 
     Cached per ``(element, basis, xc)``, so each atomic SCF runs once per process.
-    Since it only depends on the element and the basis, the result is expressed in
-    exactly the AO ordering of that element's block of the promolecule (see
-    :func:`_promolecule_mole`), where it is used. The one-electron atom (hydrogen)
-    is kept as the self-consistent DFT density (diffuse, self-interaction and
-    all), which is the MBD/TS convention. ``spin`` is set to the electron-count
-    parity only to satisfy the Mole build; the spherical-average solver fixes the
-    occupation by fractional filling.
+    Because it depends only on the element and the basis, the result comes out in
+    exactly the AO ordering of that element's block of the molecule it is used
+    with, which is what lets it be contracted against a slice of the molecular AOs.
+    The one-electron atom (hydrogen) is kept as the self-consistent DFT density
+    (diffuse, self-interaction and all), which is the MBD/TS convention. ``spin``
+    is set to the electron-count parity only to satisfy the Mole build; the
+    spherical-average solver fixes the occupation by fractional filling.
     """
     mol = gto.M(
         atom=[[symb, (0.0, 0.0, 0.0)]],

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -117,42 +117,16 @@ def _free_atom_dm(symb, basis, xc):
     return mf.make_rdm1()
 
 
-def _promolecule_mole(mol, basis_of_symbol):
-    """Mole with the free-atom basis on every atom of ``mol`` (the promolecule).
-
-    Only ever used to evaluate basis functions on a grid, never for an SCF, so
-    ``spin`` just has to match the parity of the neutral-atom electron count.
-    """
-    return gto.M(
-        atom=[
-            [mol.atom_symbol(ia), tuple(mol.atom_coord(ia))] for ia in range(mol.natm)
-        ],
-        basis=dict(basis_of_symbol),
-        unit='Bohr',
-        spin=sum(gto.charge(mol.atom_symbol(ia)) for ia in range(mol.natm)) % 2,
-        verbose=0,
-    )
-
-
-def hirshfeld_volume_ratios(
-    mf, free_atom_xc='auto', free_atom_basis=None, grid_level=3
-):
+def hirshfeld_volume_ratios(mf):
     """Per-atom Hirshfeld volume ratios from a converged PySCF Kohn--Sham object.
 
     :param mf: converged PySCF KS object (restricted or unrestricted)
-    :param free_atom_xc: functional for the free-atom reference; ``'auto'`` (the
-        default) uses the molecular functional, or pass an explicit functional
-    :param free_atom_basis: basis for the free-atom reference; ``None`` (the
-        default) uses the molecular basis, which is what makes the ratios a pure
-        measure of the chemical environment -- see below
-    :param int grid_level: fallback PySCF grid level, only used if ``mf`` has no
-        integration grid of its own
 
     Returns an array of per-atom ratios of shape ``(natm,)``.
 
     Requires an all-electron KS-DFT mean-field; Hartree--Fock (no
     exchange-correlation functional), ghost atoms and ECPs are rejected. The
-    molecular integration grid is taken from ``mf``.
+    functional, basis and integration grid are all taken from ``mf``.
 
     The free-atom reference is deliberately computed in the *molecular* basis. Any
     other choice mixes basis-set incompleteness into the ratio: a well-separated
@@ -162,9 +136,8 @@ def hirshfeld_volume_ratios(
     density. The two agree only at the basis-set limit.
     """
     mol = mf.mol
-    if free_atom_xc == 'auto':
-        free_atom_xc = getattr(mf, 'xc', None)
-    if not free_atom_xc:
+    xc = getattr(mf, 'xc', None)
+    if not xc:
         raise ValueError(
             'MBD Hirshfeld partitioning requires a KS-DFT mean-field; got one '
             'with no exchange-correlation functional (Hartree-Fock)'
@@ -183,48 +156,38 @@ def hirshfeld_volume_ratios(
             'uses an ECP, so its core density is missing and cannot be matched '
             'by a neutral free-atom reference'
         )
-    grids = getattr(mf, 'grids', None)
-    if grids is None or grids.coords is None:
-        grids = dft.gen_grid.Grids(mol)
-        grids.level = grid_level
+    grids = mf.grids  # a KS object always carries one
+    if grids.coords is None:
         grids.build()
     dm = mf.make_rdm1()
     if np.ndim(dm) == 3:  # unrestricted -> total density
         dm = dm[0] + dm[1]
 
-    # All free-atom densities come from one basis (the promolecule Mole) evaluated
-    # in a single pass over the grid: the free-atom density matrices are
-    # block-diagonal in it, so atom A's density is the contraction of A's own AO
-    # block with its cached density matrix. Grid blocking keeps the AO array
-    # bounded and lets the integrals be accumulated on the fly, so neither the
-    # (natm, ngrid) promolecule matrix nor a full AO array is ever materialized.
+    # Since the free-atom reference uses the molecular basis, the promolecule is
+    # just mol and one AO evaluation serves both the free-atom densities and the
+    # molecular one: the free-atom density matrices are block-diagonal in that
+    # basis, so atom A's density is the contraction of A's own AO block with its
+    # cached density matrix. Grid blocking keeps the AO array bounded and lets the
+    # integrals be accumulated on the fly, so neither a whole-grid AO array nor an
+    # (natm, ngrid) promolecule matrix is ever materialized.
     symbols = [mol.atom_symbol(ia) for ia in range(mol.natm)]
-    basis_of_symbol = {
-        symb: _hashable_basis(
-            mol._basis[symb] if free_atom_basis is None else free_atom_basis
-        )
-        for symb in set(symbols)
-    }
-    # With the molecular basis the promolecule Mole *is* mol, so a single AO
-    # evaluation serves both the free-atom blocks and the molecular density.
-    promol = mol if free_atom_basis is None else _promolecule_mole(mol, basis_of_symbol)
-    aoslices = promol.aoslice_by_atom()
     free_dms = [
-        _free_atom_dm(symb, basis_of_symbol[symb], free_atom_xc) for symb in symbols
+        _free_atom_dm(symb, _hashable_basis(mol._basis[symb]), xc) for symb in symbols
     ]
+    aoslices = mol.aoslice_by_atom()
     atom_coords = mol.atom_coords()
-    blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * promol.nao)))
+    blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * mol.nao)))
 
     v_eff = np.zeros(mol.natm)
     v_free = np.zeros(mol.natm)
     for i0 in range(0, len(grids.coords), blksize):
         coords = grids.coords[i0 : i0 + blksize]
         weights = grids.weights[i0 : i0 + blksize]
-        ao_free = dft.numint.eval_ao(promol, coords)
+        ao = dft.numint.eval_ao(mol, coords)
         rho_free = np.empty((mol.natm, len(coords)))
         for ia in range(mol.natm):
             _, _, p0, p1 = aoslices[ia]
-            ao_a = ao_free[:, p0:p1]
+            ao_a = ao[:, p0:p1]
             # contract via a matrix product, as eval_rho does internally: going
             # through BLAS is ~10x faster than a three-operand einsum here, and
             # the block structure avoids the (much larger) dense nao x nao product
@@ -232,8 +195,7 @@ def hirshfeld_volume_ratios(
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)
-        ao_mol = ao_free if promol is mol else dft.numint.eval_ao(mol, coords)
-        rho = dft.numint.eval_rho(mol, ao_mol, dm)
+        rho = dft.numint.eval_rho(mol, ao, dm)
         for ia in range(mol.natm):
             r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
             w = rho_free[ia] / rho_promol  # Hirshfeld weight
@@ -242,9 +204,7 @@ def hirshfeld_volume_ratios(
     return v_eff / v_free
 
 
-def mbd_energy(
-    mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip', **ratio_kwargs
-):
+def mbd_energy(mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip'):
     """MBD dispersion energy (a.u.) for a converged PySCF Kohn--Sham object.
 
     :param mf: converged PySCF KS object
@@ -254,7 +214,6 @@ def mbd_energy(
         mbd_energy` (``'rsscs'`` or ``'plain'``)
     :param float a: MBD damping steepness
     :param str damping: MBD damping function
-    :param ratio_kwargs: forwarded to :func:`hirshfeld_volume_ratios`
 
     Free-atom vdW parameters are taken from libMBD's built-in table and rescaled
     by the Hirshfeld volume ratios.
@@ -265,7 +224,7 @@ def mbd_energy(
         beta = _BETA_RSSCS.get(xc)
         if beta is None:
             raise ValueError(f'No default MBD beta for xc={xc!r}; pass beta explicitly')
-    ratios = hirshfeld_volume_ratios(mf, **ratio_kwargs)
+    ratios = hirshfeld_volume_ratios(mf)
     species = [mol.atom_symbol(i) for i in range(mol.natm)]
     alpha_0 = np.array([vdw_params[s]['alpha_0(TS)'] for s in species]) * ratios
     C6 = np.array([vdw_params[s]['C6(TS)'] for s in species]) * ratios**2

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -50,7 +50,7 @@ from pyscf import dft, gto
 from pyscf.scf import atom_hf
 
 from .fortran import MBDGeom
-from .pymbd import vdw_params
+from .pymbd import from_volumes
 
 __all__ = ['hirshfeld_volume_ratios', 'mbd_energy', 'AtomSphAverageRKS']
 
@@ -213,8 +213,8 @@ def mbd_energy(mf, beta=None, **kwargs):
     :param kwargs: passed on to :meth:`~pymbd.fortran.MBDGeom.mbd_energy`, whose
         defaults (MBD@rsSCS with Fermi dipole damping) are used as they stand
 
-    Free-atom vdW parameters are taken from libMBD's built-in table and rescaled
-    by the Hirshfeld volume ratios.
+    Free-atom vdW parameters come from libMBD's built-in table, rescaled by the
+    Hirshfeld volume ratios with :func:`~pymbd.from_volumes`.
     """
     mol = mf.mol
     if beta is None:
@@ -225,9 +225,7 @@ def mbd_energy(mf, beta=None, **kwargs):
     ratios = hirshfeld_volume_ratios(mf)
     real = _real_atoms(mol)
     species = [mol.atom_symbol(ia) for ia in real]
-    alpha_0 = np.array([vdw_params[s]['alpha_0(TS)'] for s in species]) * ratios
-    C6 = np.array([vdw_params[s]['C6(TS)'] for s in species]) * ratios**2
-    R_vdw = np.array([vdw_params[s]['R_vdw(TS)'] for s in species]) * ratios ** (1 / 3)
+    alpha_0, C6, R_vdw = from_volumes(species, ratios)
     return MBDGeom(mol.atom_coords()[real]).mbd_energy(
         alpha_0, C6, R_vdw, beta=beta, **kwargs
     )

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -28,9 +28,9 @@ is also present in the molecular density, so well-separated atoms come out at
 exactly 1 in any basis. For a one-electron atom (hydrogen) the reference is the
 diffuse, self-consistent DFT density, matching the FHI-aims/libMBD convention.
 Benchmarking against independent all-electron FHI-aims MBD energies confirms these
-choices (MBD interaction energies agree to ~0.02 kcal/mol). MBD is only meaningful
-on top of a (semi)local/hybrid KS functional, so a Hartree--Fock mean-field is
-rejected.
+choices: MBD interaction energies agree to ~0.003 kcal/mol (against ~0.016 with a
+fixed aug-cc-pVQZ reference). MBD is only meaningful on top of a
+(semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
 
 Requires PySCF (``pip install pymbd[pyscf]``).
 """

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -81,16 +81,9 @@ class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
     energy_elec = dft.rks.energy_elec
 
 
-def _hashable_basis(basis):
-    """Make a basis spec hashable (nested lists -> tuples) for use as a cache key.
-
-    A parsed per-element basis (``mol._basis[symb]``) is a nested list; PySCF
-    accepts the tuple form just as well, so the result doubles as the spec passed
-    back to :func:`pyscf.gto.M`.
-    """
-    if isinstance(basis, (list, tuple)):
-        return tuple(_hashable_basis(b) for b in basis)
-    return basis  # str basis name, or a number inside a parsed basis
+def _real_atoms(mol):
+    """Return the indices of atoms carrying a nucleus, i.e. all but ghost centers."""
+    return [ia for ia in range(mol.natm) if mol.atom_charge(ia) > 0]
 
 
 @lru_cache(maxsize=None)
@@ -108,7 +101,10 @@ def _free_atom_dm(symb, basis, xc):
     """
     mol = gto.M(
         atom=[[symb, (0.0, 0.0, 0.0)]],
-        basis={symb: basis},
+        basis=basis,
+        # the parity PySCF's own atomic solver uses (scf.atom_hf); it only has to
+        # satisfy the Mole electron-count check, since the spherical-average
+        # solver sets the occupation by fractional filling
         spin=gto.charge(symb) % 2,
         verbose=0,
     )
@@ -122,10 +118,15 @@ def hirshfeld_volume_ratios(mf):
 
     :param mf: converged PySCF KS object (restricted or unrestricted)
 
-    Returns an array of per-atom ratios of shape ``(natm,)``.
+    Returns one ratio per atom carrying a nucleus, in order. Ghost centers have no
+    free-atom reference and are skipped, so adding counterpoise ghosts leaves the
+    ratios (and hence the MBD energy) almost unchanged -- they then differ only
+    through the improvement the extra basis functions make to the molecular
+    density, not through the partitioning itself.
 
     Requires an all-electron KS-DFT mean-field; Hartree--Fock (no
-    exchange-correlation functional), ghost atoms and ECPs are rejected. The
+    exchange-correlation functional) and ECPs are rejected, as is a per-element
+    basis, since the free-atom reference is built in the molecular basis. The
     functional, basis and integration grid are all taken from ``mf``.
 
     The free-atom reference is deliberately computed in the *molecular* basis. Any
@@ -142,13 +143,11 @@ def hirshfeld_volume_ratios(mf):
             'MBD Hirshfeld partitioning requires a KS-DFT mean-field; got one '
             'with no exchange-correlation functional (Hartree-Fock)'
         )
-    ghosts = [ia for ia in range(mol.natm) if mol.atom_charge(ia) == 0]
-    if ghosts:
+    if not isinstance(mol.basis, str):
         raise ValueError(
-            'Hirshfeld partitioning is undefined for ghost atoms (no nucleus, '
-            f'hence no free-atom reference); found at atom indices {ghosts}. '
-            'Evaluate the dispersion on the ghost-free fragments: unlike the '
-            'DFT interaction energy, the MBD term needs no counterpoise.'
+            'the free-atom reference is built in the molecular basis, so that '
+            'basis has to be a single basis-set name; per-element basis sets are '
+            f'not supported (got {type(mol.basis).__name__})'
         )
     if mol.has_ecp():
         raise ValueError(
@@ -170,37 +169,35 @@ def hirshfeld_volume_ratios(mf):
     # cached density matrix. Grid blocking keeps the AO array bounded and lets the
     # integrals be accumulated on the fly, so neither a whole-grid AO array nor an
     # (natm, ngrid) promolecule matrix is ever materialized.
-    symbols = [mol.atom_symbol(ia) for ia in range(mol.natm)]
-    free_dms = [
-        _free_atom_dm(symb, _hashable_basis(mol._basis[symb]), xc) for symb in symbols
-    ]
+    real = _real_atoms(mol)
+    free_dms = [_free_atom_dm(mol.atom_symbol(ia), mol.basis, xc) for ia in real]
     aoslices = mol.aoslice_by_atom()
-    atom_coords = mol.atom_coords()
+    atom_coords = mol.atom_coords()[real]
     blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * mol.nao)))
 
-    v_eff = np.zeros(mol.natm)
-    v_free = np.zeros(mol.natm)
+    v_eff = np.zeros(len(real))
+    v_free = np.zeros(len(real))
     for i0 in range(0, len(grids.coords), blksize):
         coords = grids.coords[i0 : i0 + blksize]
         weights = grids.weights[i0 : i0 + blksize]
         ao = dft.numint.eval_ao(mol, coords)
-        rho_free = np.empty((mol.natm, len(coords)))
-        for ia in range(mol.natm):
+        rho_free = np.empty((len(real), len(coords)))
+        for i, ia in enumerate(real):
             _, _, p0, p1 = aoslices[ia]
             ao_a = ao[:, p0:p1]
             # contract via a matrix product, as eval_rho does internally: going
             # through BLAS is ~10x faster than a three-operand einsum here, and
             # the block structure avoids the (much larger) dense nao x nao product
-            rho_free[ia] = np.einsum('gi,gi->g', ao_a.dot(free_dms[ia]), ao_a)
+            rho_free[i] = np.einsum('gi,gi->g', ao_a.dot(free_dms[i]), ao_a)
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)
         rho = dft.numint.eval_rho(mol, ao, dm)
-        for ia in range(mol.natm):
-            r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
-            w = rho_free[ia] / rho_promol  # Hirshfeld weight
-            v_eff[ia] += np.einsum('g,g,g,g->', weights, w, r3, rho)
-            v_free[ia] += np.einsum('g,g,g->', weights, r3, rho_free[ia])
+        for i in range(len(real)):
+            r3 = np.linalg.norm(coords - atom_coords[i], axis=1) ** 3
+            w = rho_free[i] / rho_promol  # Hirshfeld weight
+            v_eff[i] += np.einsum('g,g,g,g->', weights, w, r3, rho)
+            v_free[i] += np.einsum('g,g,g->', weights, r3, rho_free[i])
     return v_eff / v_free
 
 
@@ -225,10 +222,11 @@ def mbd_energy(mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip'):
         if beta is None:
             raise ValueError(f'No default MBD beta for xc={xc!r}; pass beta explicitly')
     ratios = hirshfeld_volume_ratios(mf)
-    species = [mol.atom_symbol(i) for i in range(mol.natm)]
+    real = _real_atoms(mol)
+    species = [mol.atom_symbol(ia) for ia in real]
     alpha_0 = np.array([vdw_params[s]['alpha_0(TS)'] for s in species]) * ratios
     C6 = np.array([vdw_params[s]['C6(TS)'] for s in species]) * ratios**2
     R_vdw = np.array([vdw_params[s]['R_vdw(TS)'] for s in species]) * ratios ** (1 / 3)
-    return MBDGeom(mol.atom_coords()).mbd_energy(
+    return MBDGeom(mol.atom_coords()[real]).mbd_energy(
         alpha_0, C6, R_vdw, beta=beta, a=a, variant=variant, damping=damping
     )

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -20,14 +20,17 @@ free-atom densities, and rescales the free-atom vdW parameters
 (:math:`\alpha\propto v`, :math:`C_6\propto v^2`, :math:`R_\mathrm{vdw}\propto
 v^{1/3}`) before calling :class:`pymbd.fortran.MBDGeom`.
 
-The free-atom reference is a *spherically averaged Kohn--Sham* atom computed with
-the same functional as the molecule (:class:`AtomSphAverageRKS`) in a large,
-fixed basis (aug-cc-pVQZ by default). This matches the FHI-aims/libMBD
-convention: for a one-electron atom (hydrogen) the reference is the diffuse,
-self-consistent DFT density. Benchmarking against independent all-electron
-FHI-aims MBD energies confirms this choice reproduces them best (MBD interaction
-energies agree to ~0.02 kcal/mol). MBD is only meaningful on top of a
-(semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
+The free-atom reference is a *spherically averaged Kohn--Sham* atom
+(:class:`AtomSphAverageRKS`) computed with the same functional *and the same basis*
+as the molecule. Sharing the basis is what makes the ratio a pure measure of the
+chemical environment: the reference then cancels the basis-set incompleteness that
+is also present in the molecular density, so well-separated atoms come out at
+exactly 1 in any basis. For a one-electron atom (hydrogen) the reference is the
+diffuse, self-consistent DFT density, matching the FHI-aims/libMBD convention.
+Benchmarking against independent all-electron FHI-aims MBD energies confirms these
+choices (MBD interaction energies agree to ~0.02 kcal/mol). MBD is only meaningful
+on top of a (semi)local/hybrid KS functional, so a Hartree--Fock mean-field is
+rejected.
 
 Requires PySCF (``pip install pymbd[pyscf]``).
 """
@@ -71,6 +74,18 @@ class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
     energy_elec = dft.rks.energy_elec
 
 
+def _hashable_basis(basis):
+    """Make a basis spec hashable (nested lists -> tuples) for use as a cache key.
+
+    A parsed per-element basis (``mol._basis[symb]``) is a nested list; PySCF
+    accepts the tuple form just as well, so the result doubles as the spec passed
+    back to :func:`pyscf.gto.M`.
+    """
+    if isinstance(basis, (list, tuple)):
+        return tuple(_hashable_basis(b) for b in basis)
+    return basis  # str basis name, or a number inside a parsed basis
+
+
 @lru_cache(maxsize=None)
 def _free_atom_dm(symb, basis, xc):
     """Spherically averaged free-atom density matrix for one element.
@@ -95,7 +110,7 @@ def _free_atom_dm(symb, basis, xc):
     return mf.make_rdm1()
 
 
-def _promolecule_mole(mol, free_atom_basis):
+def _promolecule_mole(mol, basis_of_symbol):
     """Mole with the free-atom basis on every atom of ``mol`` (the promolecule).
 
     Only ever used to evaluate basis functions on a grid, never for an SCF, so
@@ -105,7 +120,7 @@ def _promolecule_mole(mol, free_atom_basis):
         atom=[
             [mol.atom_symbol(ia), tuple(mol.atom_coord(ia))] for ia in range(mol.natm)
         ],
-        basis=free_atom_basis,
+        basis=dict(basis_of_symbol),
         unit='Bohr',
         spin=sum(gto.charge(mol.atom_symbol(ia)) for ia in range(mol.natm)) % 2,
         verbose=0,
@@ -113,26 +128,31 @@ def _promolecule_mole(mol, free_atom_basis):
 
 
 def hirshfeld_volume_ratios(
-    mf, free_atom_xc='auto', free_atom_basis='aug-cc-pVQZ', grid_level=3
+    mf, free_atom_xc='auto', free_atom_basis=None, grid_level=3
 ):
     """Per-atom Hirshfeld volume ratios from a converged PySCF Kohn--Sham object.
 
     :param mf: converged PySCF KS object (restricted or unrestricted)
     :param free_atom_xc: functional for the free-atom reference; ``'auto'`` (the
         default) uses the molecular functional, or pass an explicit functional
-    :param str free_atom_basis: basis for the free-atom reference (fixed, large)
+    :param free_atom_basis: basis for the free-atom reference; ``None`` (the
+        default) uses the molecular basis, which is what makes the ratios a pure
+        measure of the chemical environment -- see below
     :param int grid_level: fallback PySCF grid level, only used if ``mf`` has no
         integration grid of its own
 
     Returns an array of per-atom ratios of shape ``(natm,)``.
 
-    Requires a KS-DFT mean-field; a Hartree--Fock ``mf`` (no exchange-correlation
-    functional) is rejected. The molecular integration grid is taken from ``mf``.
+    Requires an all-electron KS-DFT mean-field; Hartree--Fock (no
+    exchange-correlation functional), ghost atoms and ECPs are rejected. The
+    molecular integration grid is taken from ``mf``.
 
-    An isolated atom returns a ratio of exactly 1 only when ``free_atom_basis``
-    matches the molecular basis (or both are at the basis-set limit); with the
-    default fixed reference basis a small molecular basis leaves a systematic
-    per-atom offset that largely cancels in interaction energies.
+    The free-atom reference is deliberately computed in the *molecular* basis. Any
+    other choice mixes basis-set incompleteness into the ratio: a well-separated
+    argon dimer in def2-SVP gives 0.89 against a fixed aug-cc-pVQZ reference (a
+    21% error in :math:`C_6`) but 1.000000 against a def2-SVP one, since the
+    reference then cancels the incompleteness that is also in the molecular
+    density. The two agree only at the basis-set limit.
     """
     mol = mf.mol
     if free_atom_xc == 'auto':
@@ -150,6 +170,12 @@ def hirshfeld_volume_ratios(
             'Evaluate the dispersion on the ghost-free fragments: unlike the '
             'DFT interaction energy, the MBD term needs no counterpoise.'
         )
+    if mol.has_ecp():
+        raise ValueError(
+            'Hirshfeld volumes need the all-electron density, but this molecule '
+            'uses an ECP, so its core density is missing and cannot be matched '
+            'by a neutral free-atom reference'
+        )
     grids = getattr(mf, 'grids', None)
     if grids is None or grids.coords is None:
         grids = dft.gen_grid.Grids(mol)
@@ -165,11 +191,19 @@ def hirshfeld_volume_ratios(
     # block with its cached density matrix. Grid blocking keeps the AO array
     # bounded and lets the integrals be accumulated on the fly, so neither the
     # (natm, ngrid) promolecule matrix nor a full AO array is ever materialized.
-    promol = _promolecule_mole(mol, free_atom_basis)
+    symbols = [mol.atom_symbol(ia) for ia in range(mol.natm)]
+    basis_of_symbol = {
+        symb: _hashable_basis(
+            mol._basis[symb] if free_atom_basis is None else free_atom_basis
+        )
+        for symb in set(symbols)
+    }
+    # With the molecular basis the promolecule Mole *is* mol, so a single AO
+    # evaluation serves both the free-atom blocks and the molecular density.
+    promol = mol if free_atom_basis is None else _promolecule_mole(mol, basis_of_symbol)
     aoslices = promol.aoslice_by_atom()
     free_dms = [
-        _free_atom_dm(mol.atom_symbol(ia), free_atom_basis, free_atom_xc)
-        for ia in range(mol.natm)
+        _free_atom_dm(symb, basis_of_symbol[symb], free_atom_xc) for symb in symbols
     ]
     atom_coords = mol.atom_coords()
     blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * promol.nao)))
@@ -191,7 +225,8 @@ def hirshfeld_volume_ratios(
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)
-        rho = dft.numint.eval_rho(mol, dft.numint.eval_ao(mol, coords), dm)
+        ao_mol = ao_free if promol is mol else dft.numint.eval_ao(mol, coords)
+        rho = dft.numint.eval_rho(mol, ao_mol, dm)
         for ia in range(mol.natm):
             r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
             w = rho_free[ia] / rho_promol  # Hirshfeld weight

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -192,6 +192,9 @@ def hirshfeld_volume_ratios(mf):
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)
+        # 'LDA' is eval_rho's derivative order, not a functional: it asks for the
+        # density alone, which is all the Hirshfeld integrals use. The GGA modes
+        # would additionally return its gradient, and would need deriv=1 above.
         rho = ni.eval_rho(mol, ao, dm, mask, 'LDA')
         for i in range(len(real)):
             r3 = np.linalg.norm(coords - atom_coords[i], axis=1) ** 3

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -57,11 +57,6 @@ __all__ = ['hirshfeld_volume_ratios', 'mbd_energy', 'AtomSphAverageRKS']
 # MBD@rsSCS range-separation parameter beta per exchange-correlation functional.
 _BETA_RSSCS = {'pbe': 0.83, 'pbe0': 0.85, 'hse': 0.85}
 
-# Grid is processed in blocks: a whole-grid AO array is ngrid x nao, which runs
-# into several GB for a few dozen atoms in a triple-zeta or larger basis.
-_GRID_BLKSIZE = 8192
-_AO_BLOCK_BYTES = 128 << 20
-
 
 class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
     """Spherically averaged neutral free-atom solver with a Kohn--Sham potential.
@@ -155,9 +150,6 @@ def hirshfeld_volume_ratios(mf):
             'uses an ECP, so its core density is missing and cannot be matched '
             'by a neutral free-atom reference'
         )
-    grids = mf.grids  # a KS object always carries one
-    if grids.coords is None:
-        grids.build()
     dm = mf.make_rdm1()
     if np.ndim(dm) == 3:  # unrestricted -> total density
         dm = dm[0] + dm[1]
@@ -173,26 +165,28 @@ def hirshfeld_volume_ratios(mf):
     free_dms = [_free_atom_dm(mol.atom_symbol(ia), mol.basis, xc) for ia in real]
     aoslices = mol.aoslice_by_atom()
     atom_coords = mol.atom_coords()[real]
-    blksize = max(128, min(_GRID_BLKSIZE, _AO_BLOCK_BYTES // (8 * mol.nao)))
 
+    ni = dft.numint.NumInt()
     v_eff = np.zeros(len(real))
     v_free = np.zeros(len(real))
-    for i0 in range(0, len(grids.coords), blksize):
-        coords = grids.coords[i0 : i0 + blksize]
-        weights = grids.weights[i0 : i0 + blksize]
-        ao = dft.numint.eval_ao(mol, coords)
+    # PySCF's own grid blocking: it sizes the blocks, reuses the AO buffer and
+    # hands us the screening mask, so no whole-grid AO array is ever built.
+    for ao, mask, weights, coords in ni.block_loop(mol, mf.grids, deriv=0):
         rho_free = np.empty((len(real), len(coords)))
         for i, ia in enumerate(real):
             _, _, p0, p1 = aoslices[ia]
             ao_a = ao[:, p0:p1]
-            # contract via a matrix product, as eval_rho does internally: going
-            # through BLAS is ~10x faster than a three-operand einsum here, and
-            # the block structure avoids the (much larger) dense nao x nao product
+            # Atom A's free density is the contraction of its own AO block with
+            # its free-atom density matrix: the free-atom density matrices are
+            # block-diagonal in the molecular basis, so the off-diagonal blocks
+            # they would occupy are zero and can be skipped. Contracting as a
+            # matrix product (the way eval_rho does internally) goes through
+            # BLAS, ~10x faster than the equivalent three-operand einsum.
             rho_free[i] = np.einsum('gi,gi->g', ao_a.dot(free_dms[i]), ao_a)
         np.clip(rho_free, 0, None, out=rho_free)
         rho_promol = rho_free.sum(axis=0)
         np.maximum(rho_promol, 1e-30, out=rho_promol)
-        rho = dft.numint.eval_rho(mol, ao, dm)
+        rho = ni.eval_rho(mol, ao, dm, mask, 'LDA')
         for i in range(len(real)):
             r3 = np.linalg.norm(coords - atom_coords[i], axis=1) ** 3
             w = rho_free[i] / rho_promol  # Hirshfeld weight
@@ -201,16 +195,14 @@ def hirshfeld_volume_ratios(mf):
     return v_eff / v_free
 
 
-def mbd_energy(mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip'):
+def mbd_energy(mf, beta=None, **kwargs):
     """MBD dispersion energy (a.u.) for a converged PySCF Kohn--Sham object.
 
     :param mf: converged PySCF KS object
     :param float beta: MBD range-separation parameter; if ``None`` it is looked
         up from the molecular functional (currently PBE, PBE0, HSE)
-    :param str variant: MBD variant passed to :meth:`~pymbd.fortran.MBDGeom.
-        mbd_energy` (``'rsscs'`` or ``'plain'``)
-    :param float a: MBD damping steepness
-    :param str damping: MBD damping function
+    :param kwargs: passed on to :meth:`~pymbd.fortran.MBDGeom.mbd_energy`, whose
+        defaults (MBD@rsSCS with Fermi dipole damping) are used as they stand
 
     Free-atom vdW parameters are taken from libMBD's built-in table and rescaled
     by the Hirshfeld volume ratios.
@@ -228,5 +220,5 @@ def mbd_energy(mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip'):
     C6 = np.array([vdw_params[s]['C6(TS)'] for s in species]) * ratios**2
     R_vdw = np.array([vdw_params[s]['R_vdw(TS)'] for s in species]) * ratios ** (1 / 3)
     return MBDGeom(mol.atom_coords()[real]).mbd_energy(
-        alpha_0, C6, R_vdw, beta=beta, a=a, variant=variant, damping=damping
+        alpha_0, C6, R_vdw, beta=beta, **kwargs
     )

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -124,6 +124,13 @@ def hirshfeld_volume_ratios(mf):
     basis, since the free-atom reference is built in the molecular basis. The
     functional, basis and integration grid are all taken from ``mf``.
 
+    The ratios are barely sensitive to the integration grid, because the same grid
+    integrates both the in-molecule and the free-atom volume and the quadrature
+    error largely cancels in their ratio. On a 17-atom dimer the MBD interaction
+    energy varies by under 1e-4 kcal/mol across PySCF grid levels 1 to 4, and by
+    7e-4 between levels 0 and 4 -- at which point the SCF energy is already 16
+    kcal/mol adrift. Choose the grid for the density; the dispersion will follow.
+
     The free-atom reference is deliberately computed in the *molecular* basis. Any
     other choice mixes basis-set incompleteness into the ratio: a well-separated
     argon dimer in def2-SVP gives 0.89 against a fixed aug-cc-pVQZ reference (a

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -1,0 +1,198 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+r"""Bridge between PySCF and pyMBD via Hirshfeld volume rescaling.
+
+This optional module turns a converged PySCF mean-field object into an MBD (or
+TS) dispersion energy. It computes per-atom Hirshfeld volume ratios
+
+.. math::
+
+    v_A = \frac{\int w_A(\mathbf r)\,|\mathbf r-\mathbf R_A|^3\,
+                 \rho(\mathbf r)\,d\mathbf r}
+               {\int |\mathbf r-\mathbf R_A|^3\,
+                 \rho_A^\mathrm{free}(\mathbf r)\,d\mathbf r},
+    \qquad
+    w_A = \frac{\rho_A^\mathrm{free}}{\sum_B \rho_B^\mathrm{free}},
+
+directly from the molecular density and a promolecule of spherically averaged
+free-atom densities, and rescales the free-atom vdW parameters
+(:math:`\alpha\propto v`, :math:`C_6\propto v^2`, :math:`R_\mathrm{vdw}\propto
+v^{1/3}`) before calling :class:`pymbd.fortran.MBDGeom`.
+
+The free-atom reference is a *spherically averaged Kohn--Sham* atom computed with
+the same functional as the molecule (:class:`AtomSphAverageRKS`) in a large,
+fixed basis (aug-cc-pVQZ by default). This matches the FHI-aims/libMBD
+convention: for a one-electron atom (hydrogen) the reference is the diffuse,
+self-consistent DFT density, *not* the exact density -- benchmarking against
+independent all-electron FHI-aims MBD energies confirms this choice reproduces
+them best (MBD interaction energies agree to ~0.02 kcal/mol).
+
+Requires PySCF (``pip install pymbd[pyscf]``).
+"""
+
+from functools import lru_cache
+
+import numpy as np
+from pyscf import dft, gto
+from pyscf.scf import atom_hf
+
+from .fortran import MBDGeom
+from .pymbd import vdw_params
+
+__all__ = ['hirshfeld_volume_ratios', 'mbd_energy', 'AtomSphAverageRKS']
+
+# MBD@rsSCS range-separation parameter beta per exchange-correlation functional.
+_BETA_RSSCS = {'pbe': 0.83, 'pbe0': 0.85, 'hse': 0.85}
+
+
+class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
+    """Spherically averaged neutral free-atom solver with a Kohn--Sham potential.
+
+    Composed the way PySCF builds ``RKS = KohnShamDFT + RHF``, but with the
+    spherical-average ``eig``/``get_occ`` of :class:`pyscf.scf.atom_hf.
+    AtomSphAverageRHF`, so the free-atom density is spherical (angular averaging
+    of the Fock matrix plus fractional occupation of open shells) *and*
+    consistent with the molecular functional.
+    """
+
+    def __init__(self, mol, xc='LDA,VWN'):
+        atom_hf.AtomSphAverageRHF.__init__(self, mol)
+        dft.rks.KohnShamDFT.__init__(self, xc)
+        self.init_guess = 'vsap'
+
+    get_veff = dft.rks.get_veff
+    energy_elec = dft.rks.energy_elec
+
+
+@lru_cache(maxsize=None)
+def _free_atom_dm(symb, basis, xc, h_exact=False):
+    """Spherically averaged free-atom density matrix for one element (cached).
+
+    ``xc=None`` gives a Hartree--Fock reference; otherwise a Kohn--Sham reference
+    with functional ``xc``. A one-electron atom is routed to the exact one-body
+    solver only in the HF path or when ``h_exact`` is set; in the KS path it is
+    kept as the (diffuse, self-interaction-carrying) self-consistent DFT density,
+    which is the MBD/TS convention.
+    """
+    atm = gto.M(
+        atom=[[symb, (0.0, 0.0, 0.0)]],
+        basis={symb: basis},
+        spin=gto.charge(symb) % 2,
+        verbose=0,
+    )
+    if atm.nelectron == 1 and (xc is None or h_exact):
+        mf = atom_hf.AtomHF1e(atm)
+    elif xc is None:
+        mf = atom_hf.AtomSphAverageRHF(atm)
+    else:
+        mf = AtomSphAverageRKS(atm, xc=xc)
+    mf.kernel()
+    return mf.make_rdm1()
+
+
+def _free_atom_density_on_grid(mol, coords, xc, free_atom_basis, h_exact):
+    """Return per-atom free-atom densities on ``coords`` and their sum."""
+    rho_free = np.zeros((mol.natm, len(coords)))
+    for ia in range(mol.natm):
+        symb = mol.atom_symbol(ia)
+        dm = _free_atom_dm(symb, free_atom_basis, xc, h_exact)
+        atm = gto.M(
+            atom=[[symb, mol.atom_coord(ia, unit='Bohr')]],
+            basis={symb: free_atom_basis},
+            unit='Bohr',
+            spin=gto.charge(symb) % 2,
+            verbose=0,
+        )
+        ao = dft.numint.eval_ao(atm, coords)
+        rho_free[ia] = dft.numint.eval_rho(atm, ao, dm)
+    rho_free = np.clip(rho_free, 0, None)
+    return rho_free, rho_free.sum(axis=0)
+
+
+def hirshfeld_volume_ratios(
+    mf,
+    grid_level=3,
+    free_atom_xc='auto',
+    free_atom_basis='aug-cc-pVQZ',
+    h_exact=False,
+):
+    """Per-atom Hirshfeld volume ratios from a converged PySCF mean-field.
+
+    :param mf: converged PySCF SCF/KS object (restricted or unrestricted)
+    :param int grid_level: PySCF DFT grid level for the integration
+    :param free_atom_xc: functional for the free-atom reference; ``'auto'`` uses
+        the molecular functional (HF if ``mf`` has none), ``None`` forces HF, or
+        an explicit functional string
+    :param str free_atom_basis: basis for the free-atom reference (fixed, large)
+    :param bool h_exact: use the exact one-electron density for hydrogen instead
+        of the self-consistent DFT one (off by default; see module docstring)
+
+    Returns an array of per-atom ratios of shape ``(natm,)``.
+
+    An isolated atom returns a ratio of exactly 1 only when ``free_atom_basis``
+    matches the molecular basis (or both are at the basis-set limit); with the
+    default fixed reference basis a small molecular basis leaves a systematic
+    per-atom offset that largely cancels in interaction energies.
+    """
+    mol = mf.mol
+    if free_atom_xc == 'auto':
+        free_atom_xc = getattr(mf, 'xc', None)
+    grids = dft.gen_grid.Grids(mol)
+    grids.level = grid_level
+    grids.build()
+    coords, weights = grids.coords, grids.weights
+
+    dm = mf.make_rdm1()
+    if np.ndim(dm) == 3:  # unrestricted -> total density
+        dm = dm[0] + dm[1]
+    ao = dft.numint.eval_ao(mol, coords)
+    rho = dft.numint.eval_rho(mol, ao, dm)
+
+    rho_free, rho_promol = _free_atom_density_on_grid(
+        mol, coords, free_atom_xc, free_atom_basis, h_exact
+    )
+    rho_promol = np.where(rho_promol > 1e-30, rho_promol, 1e-30)
+
+    atom_coords = mol.atom_coords()
+    ratios = np.empty(mol.natm)
+    for ia in range(mol.natm):
+        r3 = np.linalg.norm(coords - atom_coords[ia], axis=1) ** 3
+        w = rho_free[ia] / rho_promol
+        v_eff = np.einsum('g,g,g,g->', weights, w, r3, rho)
+        v_free = np.einsum('g,g,g->', weights, r3, rho_free[ia])
+        ratios[ia] = v_eff / v_free
+    return ratios
+
+
+def mbd_energy(
+    mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip', **ratio_kwargs
+):
+    """MBD dispersion energy (a.u.) for a converged PySCF mean-field.
+
+    :param mf: converged PySCF SCF/KS object
+    :param float beta: MBD range-separation parameter; if ``None`` it is looked
+        up from the molecular functional (currently PBE, PBE0, HSE)
+    :param str variant: MBD variant passed to :meth:`~pymbd.fortran.MBDGeom.
+        mbd_energy` (``'rsscs'`` or ``'plain'``)
+    :param float a: MBD damping steepness
+    :param str damping: MBD damping function
+    :param ratio_kwargs: forwarded to :func:`hirshfeld_volume_ratios`
+
+    Free-atom vdW parameters are taken from libMBD's built-in table and rescaled
+    by the Hirshfeld volume ratios.
+    """
+    mol = mf.mol
+    if beta is None:
+        xc = getattr(mf, 'xc', 'hf').lower().replace(' ', '')
+        beta = _BETA_RSSCS.get(xc)
+        if beta is None:
+            raise ValueError(f'No default MBD beta for xc={xc!r}; pass beta explicitly')
+    ratios = hirshfeld_volume_ratios(mf, **ratio_kwargs)
+    species = [mol.atom_symbol(i) for i in range(mol.natm)]
+    alpha_0 = np.array([vdw_params[s]['alpha_0(TS)'] for s in species]) * ratios
+    C6 = np.array([vdw_params[s]['C6(TS)'] for s in species]) * ratios**2
+    R_vdw = np.array([vdw_params[s]['R_vdw(TS)'] for s in species]) * ratios ** (1 / 3)
+    return MBDGeom(mol.atom_coords()).mbd_energy(
+        alpha_0, C6, R_vdw, beta=beta, a=a, variant=variant, damping=damping
+    )

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 r"""Bridge between PySCF and pyMBD via Hirshfeld volume rescaling.
 
-This optional module turns a converged PySCF mean-field object into an MBD (or
+This optional module turns a converged PySCF Kohn--Sham object into an MBD (or
 TS) dispersion energy. It computes per-atom Hirshfeld volume ratios
 
 .. math::
@@ -24,9 +24,10 @@ The free-atom reference is a *spherically averaged Kohn--Sham* atom computed wit
 the same functional as the molecule (:class:`AtomSphAverageRKS`) in a large,
 fixed basis (aug-cc-pVQZ by default). This matches the FHI-aims/libMBD
 convention: for a one-electron atom (hydrogen) the reference is the diffuse,
-self-consistent DFT density, *not* the exact density -- benchmarking against
-independent all-electron FHI-aims MBD energies confirms this choice reproduces
-them best (MBD interaction energies agree to ~0.02 kcal/mol).
+self-consistent DFT density. Benchmarking against independent all-electron
+FHI-aims MBD energies confirms this choice reproduces them best (MBD interaction
+energies agree to ~0.02 kcal/mol). MBD is only meaningful on top of a
+(semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
 
 Requires PySCF (``pip install pymbd[pyscf]``).
 """
@@ -59,76 +60,61 @@ class AtomSphAverageRKS(dft.rks.KohnShamDFT, atom_hf.AtomSphAverageRHF):
     def __init__(self, mol, xc='LDA,VWN'):
         atom_hf.AtomSphAverageRHF.__init__(self, mol)
         dft.rks.KohnShamDFT.__init__(self, xc)
-        self.init_guess = 'vsap'
 
     get_veff = dft.rks.get_veff
     energy_elec = dft.rks.energy_elec
 
 
 @lru_cache(maxsize=None)
-def _free_atom_dm(symb, basis, xc, h_exact=False):
-    """Spherically averaged free-atom density matrix for one element (cached).
+def _free_atom(symb, basis, xc):
+    """Spherically averaged free-atom ``(Mole, density matrix)`` for one element.
 
-    ``xc=None`` gives a Hartree--Fock reference; otherwise a Kohn--Sham reference
-    with functional ``xc``. A one-electron atom is routed to the exact one-body
-    solver only in the HF path or when ``h_exact`` is set; in the KS path it is
-    kept as the (diffuse, self-interaction-carrying) self-consistent DFT density,
-    which is the MBD/TS convention.
+    Cached per ``(element, basis, xc)``, so each atomic SCF runs once per process.
+    The Mole is placed at the origin; callers evaluate it elsewhere by shifting
+    the grid. The one-electron atom (hydrogen) is kept as the self-consistent DFT
+    density (diffuse, self-interaction and all), which is the MBD/TS convention.
+    ``spin`` is set to the electron-count parity only to satisfy the Mole build;
+    the spherical-average solver fixes the occupation by fractional filling.
     """
-    atm = gto.M(
+    mol = gto.M(
         atom=[[symb, (0.0, 0.0, 0.0)]],
         basis={symb: basis},
         spin=gto.charge(symb) % 2,
         verbose=0,
     )
-    if atm.nelectron == 1 and (xc is None or h_exact):
-        mf = atom_hf.AtomHF1e(atm)
-    elif xc is None:
-        mf = atom_hf.AtomSphAverageRHF(atm)
-    else:
-        mf = AtomSphAverageRKS(atm, xc=xc)
+    mf = AtomSphAverageRKS(mol, xc=xc)
     mf.kernel()
-    return mf.make_rdm1()
+    return mol, mf.make_rdm1()
 
 
-def _free_atom_density_on_grid(mol, coords, xc, free_atom_basis, h_exact):
-    """Return per-atom free-atom densities on ``coords`` and their sum."""
+def _promolecule_densities(mol, coords, xc, free_atom_basis):
+    """Per-atom free-atom densities on ``coords`` and their sum (the promolecule)."""
     rho_free = np.zeros((mol.natm, len(coords)))
     for ia in range(mol.natm):
-        symb = mol.atom_symbol(ia)
-        dm = _free_atom_dm(symb, free_atom_basis, xc, h_exact)
-        atm = gto.M(
-            atom=[[symb, mol.atom_coord(ia, unit='Bohr')]],
-            basis={symb: free_atom_basis},
-            unit='Bohr',
-            spin=gto.charge(symb) % 2,
-            verbose=0,
-        )
-        ao = dft.numint.eval_ao(atm, coords)
+        atm, dm = _free_atom(mol.atom_symbol(ia), free_atom_basis, xc)
+        # atm is centered at the origin; shift the grid rather than rebuild a Mole
+        ao = dft.numint.eval_ao(atm, coords - mol.atom_coord(ia))
         rho_free[ia] = dft.numint.eval_rho(atm, ao, dm)
     rho_free = np.clip(rho_free, 0, None)
     return rho_free, rho_free.sum(axis=0)
 
 
 def hirshfeld_volume_ratios(
-    mf,
-    grid_level=3,
-    free_atom_xc='auto',
-    free_atom_basis='aug-cc-pVQZ',
-    h_exact=False,
+    mf, free_atom_xc='auto', free_atom_basis='aug-cc-pVQZ', grid_level=3
 ):
-    """Per-atom Hirshfeld volume ratios from a converged PySCF mean-field.
+    """Per-atom Hirshfeld volume ratios from a converged PySCF Kohn--Sham object.
 
-    :param mf: converged PySCF SCF/KS object (restricted or unrestricted)
-    :param int grid_level: PySCF DFT grid level for the integration
-    :param free_atom_xc: functional for the free-atom reference; ``'auto'`` uses
-        the molecular functional (HF if ``mf`` has none), ``None`` forces HF, or
-        an explicit functional string
+    :param mf: converged PySCF KS object (restricted or unrestricted)
+    :param free_atom_xc: functional for the free-atom reference; ``'auto'`` (the
+        default) uses the molecular functional, or pass an explicit functional
     :param str free_atom_basis: basis for the free-atom reference (fixed, large)
-    :param bool h_exact: use the exact one-electron density for hydrogen instead
-        of the self-consistent DFT one (off by default; see module docstring)
+    :param int grid_level: fallback PySCF grid level, only used if ``mf`` has no
+        integration grid of its own
 
     Returns an array of per-atom ratios of shape ``(natm,)``.
+
+    Requires a KS-DFT mean-field; a Hartree--Fock ``mf`` (no exchange-correlation
+    functional) is rejected. The molecular integration grid is taken from ``mf``.
 
     An isolated atom returns a ratio of exactly 1 only when ``free_atom_basis``
     matches the molecular basis (or both are at the basis-set limit); with the
@@ -138,19 +124,25 @@ def hirshfeld_volume_ratios(
     mol = mf.mol
     if free_atom_xc == 'auto':
         free_atom_xc = getattr(mf, 'xc', None)
-    grids = dft.gen_grid.Grids(mol)
-    grids.level = grid_level
-    grids.build()
+    if not free_atom_xc:
+        raise ValueError(
+            'MBD Hirshfeld partitioning requires a KS-DFT mean-field; got one '
+            'with no exchange-correlation functional (Hartree-Fock)'
+        )
+    grids = getattr(mf, 'grids', None)
+    if grids is None or grids.coords is None:
+        grids = dft.gen_grid.Grids(mol)
+        grids.level = grid_level
+        grids.build()
     coords, weights = grids.coords, grids.weights
 
     dm = mf.make_rdm1()
     if np.ndim(dm) == 3:  # unrestricted -> total density
         dm = dm[0] + dm[1]
-    ao = dft.numint.eval_ao(mol, coords)
-    rho = dft.numint.eval_rho(mol, ao, dm)
+    rho = dft.numint.eval_rho(mol, dft.numint.eval_ao(mol, coords), dm)
 
-    rho_free, rho_promol = _free_atom_density_on_grid(
-        mol, coords, free_atom_xc, free_atom_basis, h_exact
+    rho_free, rho_promol = _promolecule_densities(
+        mol, coords, free_atom_xc, free_atom_basis
     )
     rho_promol = np.where(rho_promol > 1e-30, rho_promol, 1e-30)
 
@@ -168,9 +160,9 @@ def hirshfeld_volume_ratios(
 def mbd_energy(
     mf, beta=None, variant='rsscs', a=6.0, damping='fermi,dip', **ratio_kwargs
 ):
-    """MBD dispersion energy (a.u.) for a converged PySCF mean-field.
+    """MBD dispersion energy (a.u.) for a converged PySCF Kohn--Sham object.
 
-    :param mf: converged PySCF SCF/KS object
+    :param mf: converged PySCF KS object
     :param float beta: MBD range-separation parameter; if ``None`` it is looked
         up from the molecular functional (currently PBE, PBE0, HSE)
     :param str variant: MBD variant passed to :meth:`~pymbd.fortran.MBDGeom.
@@ -184,7 +176,7 @@ def mbd_energy(
     """
     mol = mf.mol
     if beta is None:
-        xc = getattr(mf, 'xc', 'hf').lower().replace(' ', '')
+        xc = getattr(mf, 'xc', '').lower().replace(' ', '')
         beta = _BETA_RSSCS.get(xc)
         if beta is None:
             raise ValueError(f'No default MBD beta for xc={xc!r}; pass beta explicitly')

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -124,12 +124,17 @@ def hirshfeld_volume_ratios(mf):
     basis, since the free-atom reference is built in the molecular basis. The
     functional, basis and integration grid are all taken from ``mf``.
 
-    The ratios are barely sensitive to the integration grid, because the same grid
-    integrates both the in-molecule and the free-atom volume and the quadrature
-    error largely cancels in their ratio. On a 17-atom dimer the MBD interaction
-    energy varies by under 1e-4 kcal/mol across PySCF grid levels 1 to 4, and by
-    7e-4 between levels 0 and 4 -- at which point the SCF energy is already 16
-    kcal/mol adrift. Choose the grid for the density; the dispersion will follow.
+    The ratios are much less sensitive to the integration grid than the energy is,
+    because the same grid integrates both the in-molecule and the free-atom volume
+    and the quadrature error largely cancels in their ratio -- but only down to a
+    point, and where that point lies depends on the elements present. On an
+    aromatic 17-atom dimer the MBD interaction energy varies by under 1e-4
+    kcal/mol across PySCF grid levels 1 to 4 and by 7e-4 between levels 0 and 4, at
+    which point the SCF energy is already 16 kcal/mol adrift. Hydrogen, though,
+    carries the coarsest atomic grid, and on a hydrogen-rich aliphatic dimer
+    (pentane-pentane) level 0 costs 0.03 kcal/mol while level 1 is within 3e-4 of a
+    converged grid. Level 1 is enough for the dispersion on any of these; below
+    that it is not. Choose the grid for the density and the dispersion will follow.
 
     The free-atom reference is deliberately computed in the *molecular* basis. Any
     other choice mixes basis-set incompleteness into the ratio: a well-separated

--- a/src/pymbd/pyscf.py
+++ b/src/pymbd/pyscf.py
@@ -26,14 +26,13 @@ as the molecule. Sharing the basis is what makes the ratio a pure measure of the
 chemical environment: the reference then cancels the basis-set incompleteness that
 is also present in the molecular density, so well-separated atoms come out at
 exactly 1 in any basis. For a one-electron atom (hydrogen) the reference is the
-diffuse, self-consistent DFT density, matching the FHI-aims/libMBD convention.
-Benchmarking against independent all-electron FHI-aims MBD energies confirms these
-choices: over the full S66x8 set (528 points) the MBD interaction energies agree to
-0.03 kcal/mol MAE in aug-cc-pVDZ and 0.04 in def2-TZVP, the residual in each case
-being a systematic basis-set offset rather than scatter, and on the subset used to
-compare free-atom references the molecular-basis choice was about five times more
-accurate than a fixed aug-cc-pVQZ one. MBD is only meaningful on top of a
-(semi)local/hybrid KS functional, so a Hartree--Fock mean-field is rejected.
+diffuse, self-consistent DFT density, matching the FHI-aims/libMBD convention. MBD
+is only meaningful on top of a (semi)local/hybrid KS functional, so a
+Hartree--Fock mean-field is rejected.
+
+These choices are validated point by point against independent all-electron
+FHI-aims MBD energies over S66x8; ``devtools/pyscf_s66x8_figshare_check.py``
+reproduces that comparison.
 
 Requires PySCF (``pip install pymbd[pyscf]``)::
 
@@ -129,22 +128,17 @@ def hirshfeld_volume_ratios(mf):
 
     The ratios are much less sensitive to the integration grid than the energy is,
     because the same grid integrates both the in-molecule and the free-atom volume
-    and the quadrature error largely cancels in their ratio -- but only down to a
-    point, and where that point lies depends on the elements present. On an
-    aromatic 17-atom dimer the MBD interaction energy varies by under 1e-4
-    kcal/mol across PySCF grid levels 1 to 4 and by 7e-4 between levels 0 and 4, at
-    which point the SCF energy is already 16 kcal/mol adrift. Hydrogen, though,
-    carries the coarsest atomic grid, and on a hydrogen-rich aliphatic dimer
-    (pentane-pentane) level 0 costs 0.03 kcal/mol while level 1 is within 3e-4 of a
-    converged grid. Level 1 is enough for the dispersion on any of these; below
-    that it is not. Choose the grid for the density and the dispersion will follow.
+    and the quadrature error largely cancels in their ratio. The cancellation is
+    not unconditional, though, and how far it reaches depends on the elements
+    present: hydrogen carries the coarsest atomic grid, so hydrogen-rich systems
+    need a finer one than the cancellation alone would suggest. Choosing the grid
+    for the density is enough in practice; PySCF's coarsest level is not.
 
     The free-atom reference is deliberately computed in the *molecular* basis. Any
-    other choice mixes basis-set incompleteness into the ratio: a well-separated
-    argon dimer in def2-SVP gives 0.89 against a fixed aug-cc-pVQZ reference (a
-    21% error in :math:`C_6`) but 1.000000 against a def2-SVP one, since the
-    reference then cancels the incompleteness that is also in the molecular
-    density. The two agree only at the basis-set limit.
+    other choice mixes basis-set incompleteness into the ratio, so that a
+    well-separated dimer no longer comes out at exactly 1 and the error carries
+    straight into :math:`C_6`. A fixed reference basis is correct only at the
+    basis-set limit.
     """
     mol = mf.mol
     xc = getattr(mf, 'xc', None)

--- a/tests/test_pyscf.py
+++ b/tests/test_pyscf.py
@@ -20,17 +20,28 @@ def _water():
 @pytest.mark.no_scalapack
 @pytest.mark.parametrize('elem', ['Ne', 'Ar'])
 def test_isolated_atom_ratio_is_one(elem):
-    # With a matching free-atom basis, an isolated closed-shell atom has no
-    # environment and its Hirshfeld volume ratio must be exactly 1.
+    # An isolated closed-shell atom has no environment, so its Hirshfeld volume
+    # ratio must be exactly 1 -- which holds because the free-atom reference uses
+    # the molecular basis.
     mf = dft.RKS(gto.M(atom=f'{elem} 0 0 0', basis='def2-svp', verbose=0), xc='PBE')
     mf.run()
-    ratio = hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')[0]
-    assert ratio == approx(1.0, abs=1e-4)
+    assert hirshfeld_volume_ratios(mf)[0] == approx(1.0, abs=1e-4)
+
+
+@pytest.mark.no_scalapack
+@pytest.mark.parametrize('basis', ['def2-svp', 'def2-tzvp'])
+def test_separated_dimer_ratios_are_one(basis):
+    # A well-separated argon dimer is two free atoms, so both ratios must be 1
+    # in *any* basis. This fails against a fixed reference basis (0.89 in
+    # def2-SVP against aug-cc-pVQZ), which is why the molecular basis is used.
+    mf = dft.RKS(gto.M(atom='Ar 0 0 0; Ar 0 0 12.0', basis=basis, verbose=0), xc='PBE')
+    mf.run()
+    assert hirshfeld_volume_ratios(mf) == approx([1.0, 1.0], abs=1e-4)
 
 
 @pytest.mark.no_scalapack
 def test_water_volume_ratios():
-    ratios = hirshfeld_volume_ratios(_water(), free_atom_basis='def2-svp')
+    ratios = hirshfeld_volume_ratios(_water())
     assert ratios == approx([0.95199, 0.549794, 0.549794], abs=1e-3)
     # oxygen stays near-free, hydrogens contract strongly in the O-H bonds
     assert ratios[0] > ratios[1]
@@ -38,7 +49,7 @@ def test_water_volume_ratios():
 
 @pytest.mark.no_scalapack
 def test_water_mbd_energy():
-    ene = mbd_energy(_water(), free_atom_basis='def2-svp')
+    ene = mbd_energy(_water())
     assert ene == approx(-0.00024035, abs=1e-6)
 
 
@@ -48,7 +59,7 @@ def test_hartree_fock_is_rejected():
 
     mf = scf.RHF(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0)).run()
     with pytest.raises(ValueError, match='KS-DFT'):
-        hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')
+        hirshfeld_volume_ratios(mf)
 
 
 @pytest.mark.no_scalapack
@@ -64,7 +75,7 @@ def test_ghost_atoms_are_rejected():
     )
     mf = dft.UKS(mol, xc='PBE').run()
     with pytest.raises(ValueError, match='ghost'):
-        hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')
+        hirshfeld_volume_ratios(mf)
 
 
 @pytest.mark.no_scalapack
@@ -72,4 +83,4 @@ def test_mbd_energy_requires_known_beta():
     mf = dft.RKS(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0), xc='M06-L')
     mf.run()
     with pytest.raises(ValueError, match='beta'):
-        mbd_energy(mf, free_atom_basis='def2-svp')
+        mbd_energy(mf)

--- a/tests/test_pyscf.py
+++ b/tests/test_pyscf.py
@@ -1,0 +1,50 @@
+import pytest
+from pytest import approx
+
+pyscf = pytest.importorskip('pyscf')
+
+from pyscf import dft, gto  # noqa: E402
+
+from pymbd.pyscf import hirshfeld_volume_ratios, mbd_energy  # noqa: E402
+
+
+def _water():
+    mol = gto.M(
+        atom='O 0 0 0.1173; H 0 0.7572 -0.4692; H 0 -0.7572 -0.4692',
+        basis='def2-svp',
+        verbose=0,
+    )
+    return dft.RKS(mol, xc='PBE').run()
+
+
+@pytest.mark.no_scalapack
+@pytest.mark.parametrize('elem', ['Ne', 'Ar'])
+def test_isolated_atom_ratio_is_one(elem):
+    # With a matching free-atom basis, an isolated closed-shell atom has no
+    # environment and its Hirshfeld volume ratio must be exactly 1.
+    mf = dft.RKS(gto.M(atom=f'{elem} 0 0 0', basis='def2-svp', verbose=0), xc='PBE')
+    mf.run()
+    ratio = hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')[0]
+    assert ratio == approx(1.0, abs=1e-4)
+
+
+@pytest.mark.no_scalapack
+def test_water_volume_ratios():
+    ratios = hirshfeld_volume_ratios(_water(), free_atom_basis='def2-svp')
+    assert ratios == approx([0.95199, 0.549794, 0.549794], abs=1e-3)
+    # oxygen stays near-free, hydrogens contract strongly in the O-H bonds
+    assert ratios[0] > ratios[1]
+
+
+@pytest.mark.no_scalapack
+def test_water_mbd_energy():
+    ene = mbd_energy(_water(), free_atom_basis='def2-svp')
+    assert ene == approx(-0.00024035, abs=1e-6)
+
+
+@pytest.mark.no_scalapack
+def test_mbd_energy_requires_known_beta():
+    mf = dft.RKS(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0), xc='M06-L')
+    mf.run()
+    with pytest.raises(ValueError, match='beta'):
+        mbd_energy(mf, free_atom_basis='def2-svp')

--- a/tests/test_pyscf.py
+++ b/tests/test_pyscf.py
@@ -63,18 +63,31 @@ def test_hartree_fock_is_rejected():
 
 
 @pytest.mark.no_scalapack
-def test_ghost_atoms_are_rejected():
-    # counterpoise fragments carry ghost centers, which have no free-atom
-    # reference; silently they would give a zero free volume (NaN ratio)
+def test_ghost_atoms_leave_the_energy_invariant():
+    # Ghost centers have no free-atom reference, so they take no part in the
+    # partitioning. Adding a counterpoise ghost fragment may then only change the
+    # result through the molecular density, which is a tiny effect.
+    water = 'O 0 0 0.1173; H 0 0.7572 -0.4692; H 0 -0.7572 -0.4692'
+    ghosts = 'ghost:O 0 0 6.0; ghost:H 0 0.757 5.53; ghost:H 0 -0.757 5.53'
+    bare = dft.RKS(gto.M(atom=water, basis='def2-svp', verbose=0), xc='PBE').run()
+    ghosted = dft.RKS(
+        gto.M(atom=f'{water}; {ghosts}', basis='def2-svp', verbose=0), xc='PBE'
+    ).run()
+    ratios = hirshfeld_volume_ratios(ghosted)
+    assert len(ratios) == 3  # the ghosts are skipped, not partitioned
+    assert ratios == approx(hirshfeld_volume_ratios(bare), abs=1e-3)
+    assert mbd_energy(ghosted) == approx(mbd_energy(bare), abs=1e-7)
+
+
+@pytest.mark.no_scalapack
+def test_per_element_basis_is_rejected():
     mol = gto.M(
-        atom=[['O', (0, 0, 0)], ['H', (0, 0, 1.8)], ['ghost:O', (0, 0, 5.0)]],
-        basis='def2-svp',
-        unit='Bohr',
-        spin=1,
+        atom='O 0 0 0.1173; H 0 0.7572 -0.4692; H 0 -0.7572 -0.4692',
+        basis={'O': 'def2-tzvp', 'H': 'def2-svp'},
         verbose=0,
     )
-    mf = dft.UKS(mol, xc='PBE').run()
-    with pytest.raises(ValueError, match='ghost'):
+    mf = dft.RKS(mol, xc='PBE').run()
+    with pytest.raises(ValueError, match='basis-set name'):
         hirshfeld_volume_ratios(mf)
 
 

--- a/tests/test_pyscf.py
+++ b/tests/test_pyscf.py
@@ -43,6 +43,15 @@ def test_water_mbd_energy():
 
 
 @pytest.mark.no_scalapack
+def test_hartree_fock_is_rejected():
+    from pyscf import scf
+
+    mf = scf.RHF(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0)).run()
+    with pytest.raises(ValueError, match='KS-DFT'):
+        hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')
+
+
+@pytest.mark.no_scalapack
 def test_mbd_energy_requires_known_beta():
     mf = dft.RKS(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0), xc='M06-L')
     mf.run()

--- a/tests/test_pyscf.py
+++ b/tests/test_pyscf.py
@@ -52,6 +52,22 @@ def test_hartree_fock_is_rejected():
 
 
 @pytest.mark.no_scalapack
+def test_ghost_atoms_are_rejected():
+    # counterpoise fragments carry ghost centers, which have no free-atom
+    # reference; silently they would give a zero free volume (NaN ratio)
+    mol = gto.M(
+        atom=[['O', (0, 0, 0)], ['H', (0, 0, 1.8)], ['ghost:O', (0, 0, 5.0)]],
+        basis='def2-svp',
+        unit='Bohr',
+        spin=1,
+        verbose=0,
+    )
+    mf = dft.UKS(mol, xc='PBE').run()
+    with pytest.raises(ValueError, match='ghost'):
+        hirshfeld_volume_ratios(mf, free_atom_basis='def2-svp')
+
+
+@pytest.mark.no_scalapack
 def test_mbd_energy_requires_known_beta():
     mf = dft.RKS(gto.M(atom='Ne 0 0 0', basis='def2-svp', verbose=0), xc='M06-L')
     mf.run()


### PR DESCRIPTION
## Summary

Adds an optional `pymbd.pyscf` module that turns any converged PySCF Kohn–Sham object into an MBD (or TS) dispersion energy. It computes per-atom **Hirshfeld volume ratios** from the molecular density and a promolecule of spherically averaged free-atom densities, and hands them to `from_volumes` + `MBDGeom`.

```python
from pyscf import dft, gto
from pymbd.pyscf import mbd_energy

mol = gto.M(atom='He 0 0 0; He 0 0 3', basis='def2-tzvp')
mf = dft.RKS(mol, xc='PBE').run()
ene = mbd_energy(mf)          # MBD@rsSCS, beta inferred from the functional
```

Public API: `hirshfeld_volume_ratios(mf)`, `mbd_energy(mf, beta=None, **kwargs)` (kwargs go to `MBDGeom.mbd_energy`), and the `AtomSphAverageRKS` free-atom solver.

## The free-atom reference

A **spherically averaged Kohn–Sham atom** (`AtomSphAverageRKS` — composed like PySCF's `RKS = KohnShamDFT + RHF`, but with the spherical-average `eig`/`get_occ`), computed with the **same functional and the same basis as the molecule**.

Sharing the basis is the important part: it makes the ratio a pure measure of the chemical environment, because the reference cancels the basis-set incompleteness that is also present in the molecular density. A well-separated argon dimer is just two free atoms and must give exactly 1:

| molecular basis | vs fixed aug-cc-pVQZ reference | vs molecular-basis reference |
|---|---|---|
| def2-SVP | 0.888 (→ 21% error in C₆) | **1.000000** |
| def2-TZVP | 0.968 | **1.000000** |
| aug-cc-pVTZ | 1.001 | **1.000000** |

A fixed reference basis is only correct at the basis-set limit. This is also the faithful translation of the FHI-aims convention to Gaussians, since FHI-aims' NAO basis contains its free-atom orbitals by construction.

For hydrogen the reference is the diffuse, self-consistent DFT density, *not* the exact one-electron density — that is the convention the tabulated free-atom parameters were calibrated against, and it was confirmed by benchmarking (exact-H was worse, with a larger worst case).

## Validation

Benchmarked against the FHI-aims MBD@rsSCS data from Hermann & Tkatchenko, *JCTC* **2018** (doi:10.1021/acs.jctc.7b01172), whose processed results are on figshare. FHI-aims shares no code, basis, or Hirshfeld implementation with PySCF/pyMBD, so this is an independent cross-code check of the MBD term.

Over the **complete S66x8 set — all 528 points**, 66 systems × 8 separations, at PBE:

| basis | MBD MAE | max \|Δ\| | bias | mean rel. dev. | wall time |
|---|---|---|---|---|---|
| **aug-cc-pVDZ** | **0.029** | 0.117 | +0.029 | **−1.6%** | 102 min |
| def2-TZVP | 0.044 | 0.128 | −0.044 | +3.0% | 93 min |
| def2-SVP | 0.094 | 0.293 | −0.094 | +5.9% | 53 min |

The residual is a **systematic offset rather than scatter**: the MAE equals the \|bias\| to four decimals in every basis, and 96–99% of the 528 points deviate in the same direction (the dissenters being points whose deviation is essentially zero). aug-cc-pVDZ and def2-TZVP bracket the reference from opposite sides — aug-cc-pVDZ underbinds, def2-TZVP overbinds — which is what two incomplete bases either side of the basis-set limit should do, and is a consistency check on the reference itself.

### Propagated to the actual benchmark

Substituting our MBD term into the paper's own all-electron PBE interaction energies isolates the bridge: the DFT part is then identical to the reference, so any change in the error against CCSD(T)/CBS is attributable to the dispersion term alone. (Our own PBE energies carry basis-set incompleteness and, with no counterpoise, BSSE, which would swamp it.)

| dispersion term | MAE | bias | **MARE vs CCSD(T)** |
|---|---|---|---|
| FHI-aims MBD (reference) | 0.318 | −0.145 | **10.1%** |
| ours, aug-cc-pVDZ | 0.315 | −0.116 | **10.1%** |
| ours, def2-TZVP | 0.330 | −0.189 | **10.6%** |
| ours, def2-SVP | 0.346 | −0.239 | **11.4%** |
| PBE, no vdW at all | 1.547 | +1.536 | 65.6% |

The reference row reproduces the published MAE 0.318 / MARE 10.1%, which also checks that the surrounding framework is wired up correctly. Swapping in our MBD term is **invisible at aug-cc-pVDZ and costs 0.5 points at def2-TZVP**; the penalty is sublinear in the MBD deviation (5.9% → +1.3 points, 3.0% → +0.5, 1.6% → nothing measurable). Against a 10.1% method error the bridge stops mattering once it is inside ~2%.

Per separation, with the reference's PBE in both totals:

| scale | MBD rel. dev. | MARE (our MBD) | MARE (reference) |
|---|---|---|---|
| 0.90 | −1.59% | 28.2% | 26.6% |
| 0.95 | −1.68% | 11.4% | 11.1% |
| 1.00 | −1.75% | 8.4% | 8.4% |
| 1.05 | −1.79% | 7.1% | 7.2% |
| 1.10 | −1.83% | 6.5% | 6.9% |
| 1.25 | −1.82% | 6.9% | 7.5% |
| 1.50 | −1.54% | 8.1% | 8.7% |
| 2.00 | −0.88% | 4.2% | 4.5% |

Worth not over-reading aug-cc-pVDZ's marginally *better* overall MAE and bias than the reference: that is error cancellation, not superiority. PBE+MBD overbinds S66x8 (bias −0.145) and aug-cc-pVDZ's slight underbinding offsets part of it — hence worse than the reference at the most compressed geometry and better at long range. def2-SVP shows the same effect far more strongly, being the best of all four at scale 0.90 (22.4%) and the worst at 2.00 (~8.4% against 4.5%). Ranking bases on the short separations alone would order them backwards.

### What the basis has to supply is diffuse functions, not zeta level

The `r³` weight in the volume integrals probes the density tail, so augmentation matters more than cardinal number — an augmented *double*-zeta set beats an unaugmented triple-zeta one. Mean relative deviation from FHI-aims over nine systems spanning the classes, at equilibrium:

| system | def2-SVP | ma-def2-SVP | def2-SVPD | aug-cc-pVDZ | def2-TZVP | ma-def2-TZVP |
|---|---|---|---|---|---|---|
| Water···Water | −2.2% | +5.0% | +5.6% | −1.0% | −0.0% | +3.5% |
| Water···MeOH | +0.8% | +5.3% | +6.1% | −1.5% | +1.6% | +3.4% |
| MeOH···Water | +2.1% | +5.5% | +5.7% | −1.3% | +1.7% | +3.2% |
| Uracil···Ethyne | +5.4% | +1.7% | +7.6% | −1.7% | +2.3% | +0.4% |
| Pyridine···Ethene | +6.9% | +3.5% | +10.6% | −2.1% | +3.4% | +1.5% |
| Pentane···Pentane | +4.8% | +2.1% | +6.3% | −2.1% | +2.4% | +0.7% |
| Ethyne···Ethyne (TS) | +5.9% | +2.3% | +8.8% | −2.1% | +3.1% | +1.0% |
| Ethyne···Water (CH-O) | +1.5% | +5.2% | +8.1% | −1.5% | +1.6% | +3.3% |
| Ethyne···AcOH (OH-pi) | +5.1% | +1.7% | +5.3% | −1.6% | +2.3% | +0.6% |
| **mean \|dev\|** | 3.8% | 3.6% | 7.1% | **1.7%** | 2.0% | 1.9% |
| **max \|dev\|** | 6.9% | 5.5% | 10.6% | **2.1%** | 3.4% | 3.5% |
| mean nao | 115 | 113 | 174 | 194 | 215 | 237 |

Augmentation has to be **even-handed across elements**, because the ratio is taken against a promolecule rather than against the atom alone. The `ma-` sets augment heavy atoms only; that makes their free-atom densities more diffuse, shifts promolecule weight away from hydrogen, and moves hydrogen's ratio even where its own basis is untouched. The result is not an improvement but a *reallocation*: π-stacked and aliphatic systems get better, hydrogen-bonded ones get worse by about as much (water dimer −2.2% → +5.0%), for no net gain. `def2-SVPD`, whose diffuse exponents are optimized for anions and response properties rather than the neutral-atom tail, is worse than plain `def2-SVP`. Only aug-cc-pVDZ, which augments every element, gives a single-signed, near-uniform offset.

(Caveat on the `ma-def2-SVP` column specifically: PySCF's `ma-def2-svp` gives hydrogen 2 AOs — a bare 2s, no polarization, against def2-SVP's 2s1p. So that column confounds heavy-atom augmentation with hydrogen depolarization. `ma-def2-TZVP` leaves hydrogen at 6 AOs and shows the same reallocation, which is what the argument rests on.)

`devtools/pyscf_s66x8_figshare_check.py` reproduces all of this (fetches the figshare `all-data.h5`, reads geometries from a `vdwsets` checkout) and reports the MBD deviation, both MAREs, and the per-separation breakdown directly.

## Performance

**In the bridge.** The free-atom density matrices are block-diagonal in the molecular basis, so all free-atom densities come from a **single AO pass** rather than one per atom, each atom's block contracted through BLAS. Because the free-atom reference uses the molecular basis, the promolecule *is* `mol`, so that one evaluation serves the molecular density too. Grid blocking is delegated to `NumInt.block_loop`, which sizes the blocks and reuses the AO buffer, so no whole-grid AO array (several GB for a few dozen atoms) is ever built, and the integrals are accumulated per block so no `natm × ngrid` promolecule matrix is either. On a 17-atom S66 dimer this took the Hirshfeld step from 14.8 s to 1.34 s.

**In the validation driver**, where ~95% of the time is the DFT rather than the bridge:

| change | effect |
|---|---|
| each monomer computed once per system (they are shared by all 8 separations) | 24 SCFs per system → 10 |
| each point starts from the previous point's converged density | −20% |
| grid level 1 (PySCF's default is 3) | MBD within 3e-4 kcal/mol of a converged grid |
| SCF threshold 1e-4 (PySCF's default is 1e-9) | MBD shifts 0.0002 mean / 0.002 max |

Together these put the complete 528-point set at 1.5–1.7 h, from ~8 h originally.

The grid and threshold reductions rest on the same cancellation as the Ar-dimer invariant: the same grid and the same density enter both `V_eff` and `V_free`, so the error largely divides out of the ratio. They are deliberately confined to the driver — the module changes no defaults, since the right grid and threshold depend on what the caller needs from the DFT.

**How far that cancellation goes is element-dependent, and level 0 is too far.** An earlier revision defaulted to grid 0 on the strength of an aromatic dimer, where levels 0–4 span 7e-4 kcal/mol. That does not generalize: hydrogen carries the coarsest atomic grid, and on pentane···pentane — the most hydrogen-rich system in S66 — level 0 is 0.029 kcal/mol off, which was the single largest deviation in the full run and a pure artifact. Level 1 lands within 3e-4 there. The aliphatic systems, not the aromatic ones, set the requirement.

Separately, `OPENBLAS_NUM_THREADS=1` is worth ~2.2× here: where OpenBLAS and PySCF's OpenMP both claim every core they contend badly (a water dimer took 1.28 s against 0.15 s pinned). The driver's usage line leads with it.

Three further knobs were measured and rejected: LDA for the SCF (a systematic +0.003 bias and no faster, since the cost is grid machinery rather than gradient terms), a smaller DF auxiliary basis (error negligible but 30% *slower*, worse-conditioned fit), and taking the complex's ratios from its isolated monomers — the big one at ~5×, but it costs up to 0.049 kcal/mol, largest at short separation and for π systems, i.e. exactly the density polarization the partitioning exists to capture.

## Behaviour worth calling out

- **Ghost atoms are transparent.** They carry no nucleus and hence no free-atom reference, so they take no part in the partitioning and are dropped from the geometry passed to MBD. Adding a counterpoise ghost fragment to a water monomer moves the volume ratios by 5e-5 and the MBD energy by 3e-9 a.u., i.e. counterpoise fragments just work.
- **The driver's reported PBE column gets *worse* with the augmented default** (MAE 0.50 vs def2-TZVP's 0.33), because it applies no counterpoise correction and diffuse functions inflate BSSE. It is disclaimed as basis + BSSE + grid rather than a bridge diagnostic, but the direction is counterintuitive enough to be worth stating: choosing the basis for the MBD term and reading the DFT column are different jobs.

## Rejected inputs

Hirshfeld partitioning is not defined for these, so they raise rather than return silently wrong numbers:

- **Hartree–Fock** — MBD is only meaningful on a (semi)local/hybrid functional.
- **ECPs** — the core hole cannot be matched by a neutral all-electron free-atom reference.
- **Per-element basis sets** — the free-atom reference is built in the molecular basis, so that basis has to be a single basis-set name.

## Changes

- `src/pymbd/pyscf.py` — the bridge (optional; PySCF imported lazily)
- `tests/test_pyscf.py` — separated-Ar-dimer and isolated-atom invariants, ghost invariance, water regression, and the three rejection paths; auto-skipped when PySCF is absent
- `devtools/pyscf_s66x8_figshare_check.py` — the cross-code validation driver
- `pyproject.toml` — optional `[pyscf]` extra; `pyscf.py` added to the coverage `omit` list alongside the other optional modules
- `doc/conf.py`, `doc/api.rst` — mock `pyscf` for the `-W` docs build, autodoc entry

## Notes

- `pyscf` is optional, so `tests/test_pyscf.py` is skipped in CI; exercising it would mean adding PySCF to the test job.
- The docstrings state the reasoning behind the defaults but not the measurements behind it — those live here, and the driver reproduces them on demand.
- `codecov/project` posts a red status mid-matrix on every push here (79.66%, −5.15%) and settles green (84.8%) once all coverage flags upload; `codecov/patch` is green immediately. Observed on three separate pushes, including one that changed only docstrings. Nothing to fix in this diff — this file is ~86 statements against a ~4500-statement project, so it cannot account for a 5% swing.
- `_BETA_RSSCS` duplicates the xc→beta table in `mbd_damping.F90:108-118`. It can't currently be reused because `cmbd_init_damping` takes `beta` as a plain double, so the lookup never crosses the C API — happy to expose it here or separately.
- Possible follow-ups: skipping grid points where a free-atom density is negligible (13–21% of atom-point pairs at a safe threshold on a 17-atom system, growing with size; needs a per-element cutoff radius, since the AO screening mask is far too permissive — only 0.0% of atom × subblock pairs are fully negligible by that criterion); exposing `from_volumes`' `kind` for the BG/TSsurf parameter sets; a `ts_energy` convenience wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)