### PR TITLE
Drop the refs distillation from the S66x8 benchmark

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -34,49 +34,6 @@ env:
   PYTHON_VERSION: '3.12'
 
 jobs:
-  # Fetch both external inputs once and hand the shards a 300 kB tarball
-  # instead of eight downloads of the 185 MB figshare store.
-  prefetch:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/cache@v5
-        with:
-          path: ~/s66x8-cache
-          key: s66x8-h5-${{ env.H5_SHA256 }}
-      - name: Fetch all-data.h5 from figshare
-        run: |
-          mkdir -p ~/s66x8-cache
-          if [ ! -f ~/s66x8-cache/all-data.h5 ]; then
-            curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
-              -o ~/s66x8-cache/all-data.h5.part \
-              https://ndownloader.figshare.com/files/9775933
-            mv ~/s66x8-cache/all-data.h5.part ~/s66x8-cache/all-data.h5
-          fi
-          echo "$H5_SHA256  $HOME/s66x8-cache/all-data.h5" | sha256sum -c -
-      - name: Fetch the pinned vdwsets geometries
-        run: |
-          git init -q vdwsets-clone
-          git -C vdwsets-clone remote add origin https://github.com/azag0/vdwsets
-          git -C vdwsets-clone fetch -q --depth 1 origin "$VDWSETS_REF"
-          git -C vdwsets-clone checkout -q FETCH_HEAD
-          mkdir -p data/vdwsets/vdwsets/data
-          cp -r vdwsets-clone/vdwsets/data/s66x8 data/vdwsets/vdwsets/data/
-      - name: Distil the reference values
-        # pandas and tables are needed only here, to read the HDF5 store
-        run: |
-          pip install numpy pandas tables
-          python devtools/pyscf_s66x8_figshare_check.py \
-            --h5 ~/s66x8-cache/all-data.h5 --dump-refs data/refs.json
-      - uses: actions/upload-artifact@v4
-        with:
-          name: s66x8-data
-          path: data/
-
   # Filter the shard layout down to what was dispatched, so a run over three
   # systems does not also produce five green check marks for empty shards.
   setup:
@@ -140,7 +97,7 @@ jobs:
           PY
 
   benchmark:
-    needs: [setup, prefetch]
+    needs: setup
     if: needs.setup.outputs.has_jobs == 'true'
     name: s66x8 ${{ matrix.batch_id }}
     runs-on: ubuntu-latest
@@ -181,11 +138,30 @@ jobs:
           python3 -m venv $HOME/env
           $HOME/env/bin/pip install -U pip
       - name: Build & install libMBD and pyMBD
-        run: make install PYMBD_EXTRAS=pyscf
-      - uses: actions/download-artifact@v4
+        # pandas and tables read the HDF5 store
+        run: |
+          make install PYMBD_EXTRAS=pyscf
+          pip install pandas tables
+      - uses: actions/cache@v5
         with:
-          name: s66x8-data
-          path: data
+          path: ~/s66x8-cache
+          key: s66x8-h5-${{ env.H5_SHA256 }}
+      - name: Fetch all-data.h5 from figshare
+        run: |
+          mkdir -p ~/s66x8-cache
+          if [ ! -f ~/s66x8-cache/all-data.h5 ]; then
+            curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
+              -o ~/s66x8-cache/all-data.h5.part \
+              https://ndownloader.figshare.com/files/9775933
+            mv ~/s66x8-cache/all-data.h5.part ~/s66x8-cache/all-data.h5
+          fi
+          echo "$H5_SHA256  $HOME/s66x8-cache/all-data.h5" | sha256sum -c -
+      - name: Fetch the pinned vdwsets geometries
+        run: |
+          git init -q vdwsets
+          git -C vdwsets remote add origin https://github.com/azag0/vdwsets
+          git -C vdwsets fetch -q --depth 1 origin "$VDWSETS_REF"
+          git -C vdwsets checkout -q FETCH_HEAD
       - name: Run the shard
         env:
           BATCH: ${{ matrix.batch_id }}
@@ -196,7 +172,7 @@ jobs:
         run: |
           read -ra idx <<< "$SYSTEMS"
           python devtools/pyscf_s66x8_figshare_check.py \
-            --vdwsets data/vdwsets --refs data/refs.json \
+            --vdwsets vdwsets --h5 ~/s66x8-cache/all-data.h5 \
             --basis "$BASIS" --grid "$GRID" --conv-tol "$CONV_TOL" \
             --idx "${idx[@]}" \
             --out-json "results/s66x8-${BATCH}.json"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -250,6 +250,7 @@ jobs:
         run: make test_libmbd
       - name: Test pyMBD
         run: |
+          set -o pipefail
           make test -o test_libmbd RUN_CMD="coverage run -m" | tee output
           ! grep failed output >/dev/null
       - name: Generate coverage reports
@@ -297,12 +298,16 @@ jobs:
       matrix:
         # intel -> ifx + icx (LLVM-based), intel-classic -> ifort (last release)
         toolchain: [intel, intel-classic]
-    env:
-      VIRTUAL_ENV: ${{ github.workspace }}/env
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set environment variables
+        # Outside the workspace: an untracked directory inside it makes
+        # poetry-dynamic-versioning stamp pyMBD as dirty, and pymbd.fortran
+        # then refuses to import because its git suffix no longer matches
+        # the one libMBD got from git describe.
+        run: echo VIRTUAL_ENV=$HOME/env >>$GITHUB_ENV
       - name: Set up Intel Fortran/C compiler
         id: setup-fortran
         uses: fortran-lang/setup-fortran@v1
@@ -349,6 +354,7 @@ jobs:
         run: make test_libmbd
       - name: Test pyMBD
         run: |
+          set -o pipefail
           make test -o test_libmbd | tee output
           ! grep failed output >/dev/null
   pr-gate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optional `pymbd.pyscf` bridge turning a converged PySCF Kohn–Sham object into an MBD or TS dispersion energy via Hirshfeld volume ratios ([#145](https://github.com/libmbd/libmbd/pull/145))
 
+### Fixed
+
+- pyMBD failing to import its C extension (`undefined symbol: cmbd_nonint_density`) when libMBD is built with gfortran 16.2, which no longer exports the two density bindings that were missing from the C API module's public list ([#147](https://github.com/libmbd/libmbd/pull/147))
+
 ## [0.15.0] - 2026-07-24
 
 ### Added

--- a/devtools/pyscf_s66x8_figshare_check.py
+++ b/devtools/pyscf_s66x8_figshare_check.py
@@ -61,17 +61,14 @@ Data (downloaded/located, not shipped):
   * geometries + labels from the vdwsets data files (read directly, no import)
     https://github.com/azag0/vdwsets  (git clone it and pass --vdwsets)
 
-Requires ``pyscf`` and a pyMBD with the compiled extension; reading the figshare
-HDF5 additionally needs ``pandas`` and ``tables``. ``--dump-refs`` distils it
-once into a small JSON that ``--refs`` reads back with neither.
+Requires ``pyscf``, ``pandas``, ``tables`` and a pyMBD with the compiled
+extension.
 
 Usage:
     OPENBLAS_NUM_THREADS=1 python pyscf_s66x8_figshare_check.py \\
         --vdwsets /path/to/vdwsets/clone \\
-        [--h5 all-data.h5 | --refs refs.json] [--idx 1 2 8 32 33 51 59 60] \\
+        [--h5 all-data.h5] [--idx 1 2 8 32 33 51 59 60] \\
         [--basis aug-cc-pvdz] [--out-json results/s66x8-b0.json]
-
-    python pyscf_s66x8_figshare_check.py --h5 all-data.h5 --dump-refs refs.json
 
 Almost all the run time is the DFT itself, so it is worth giving OpenBLAS a
 single thread and leaving the rest to PySCF's OpenMP: where the two thread pools
@@ -101,7 +98,7 @@ H5_URL = 'https://ndownloader.figshare.com/files/9775933'
 MBD_A, MBD_BETA = 6.0, 0.83
 # separations per system in S66x8; a curve with fewer points ran short
 N_SCALES = 8
-# version of the --out-json and --refs payloads, checked by the aggregator
+# version of the --out-json payload, checked by the aggregator
 SCHEMA = 1
 
 
@@ -159,6 +156,7 @@ def ensure_h5(path):
 
 
 def load_paper(h5_path):
+    """Return the reference values as {'pbe'|'mbd'|'ref': {(label, scale): value}}."""
     import pandas as pd
 
     with pd.HDFStore(str(h5_path), 'r') as store:
@@ -169,49 +167,6 @@ def load_paper(h5_path):
     pbe = {(_norm(s), float(d)): v for (s, d), v in scf['ene'].items()}
     ref = {(_norm(s), float(d)): v for (s, d), v in scf['ref'].items()}
     mbd = {(_norm(s), float(d)): v for (s, d), v in mbd.items()}
-    return pbe, mbd, ref
-
-
-def dump_refs(h5_path, out_path):
-    """Distil the reference values this script uses out of the 185 MB HDF5 store.
-
-    Only the points present in all three tables, which is what the run loop
-    consumes. Lets a sharded run fetch figshare once rather than once per shard.
-    """
-    pbe, mbd, ref = load_paper(h5_path)
-    keys = sorted(pbe.keys() & mbd.keys() & ref.keys())
-    payload = {
-        'schema': SCHEMA,
-        'source': H5_URL,
-        'mbd_a': MBD_A,
-        'mbd_beta': MBD_BETA,
-        'points': [
-            {'label': lbl, 'scale': scale, 'pbe': pbe[k], 'mbd': mbd[k], 'ref': ref[k]}
-            for k in keys
-            for lbl, scale in [k]
-        ],
-    }
-    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(out_path, 'w') as f:
-        json.dump(payload, f)
-    print(f'wrote {len(keys)} reference points -> {out_path}')
-
-
-def load_refs(args):
-    """Return the reference values as {'pbe'|'mbd'|'ref': {(label, scale): value}}."""
-    if args.refs:
-        with open(args.refs) as f:
-            payload = json.load(f)
-        if payload.get('schema') != SCHEMA:
-            raise SystemExit(f'{args.refs}: unsupported schema {payload.get("schema")}')
-        if (payload['mbd_a'], payload['mbd_beta']) != (MBD_A, MBD_BETA):
-            raise SystemExit(f'{args.refs}: MBD parameters differ from this script')
-        pts = payload['points']
-        return {
-            k: {(p['label'], p['scale']): p[k] for p in pts}
-            for k in ('pbe', 'mbd', 'ref')
-        }
-    pbe, mbd, ref = load_paper(ensure_h5(Path(args.h5)))
     return {'pbe': pbe, 'mbd': mbd, 'ref': ref}
 
 
@@ -458,18 +413,8 @@ def format_report(rows, seen, meta, failed=()):
 
 def parse_args(argv):
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument('--vdwsets', help='path to a vdwsets checkout')
+    p.add_argument('--vdwsets', required=True, help='path to a vdwsets checkout')
     p.add_argument('--h5', default='all-data.h5', help='path to all-data.h5')
-    p.add_argument(
-        '--refs',
-        help='reference values from a previous --dump-refs, read instead of --h5 '
-        '(needs neither pandas nor tables)',
-    )
-    p.add_argument(
-        '--dump-refs',
-        metavar='PATH',
-        help='distil --h5 into a small JSON for --refs and exit, running nothing',
-    )
     p.add_argument('--basis', default='aug-cc-pvdz')
     p.add_argument('--xc', default='PBE')
     p.add_argument(
@@ -499,19 +444,12 @@ def parse_args(argv):
         metavar='PATH',
         help='write the per-point results here, for pyscf_s66x8_aggregate.py',
     )
-    args = p.parse_args(argv)
-    if not args.dump_refs and not args.vdwsets:
-        p.error('--vdwsets is required unless --dump-refs is given')
-    return args
+    return p.parse_args(argv)
 
 
 def main(argv=None):
     args = parse_args(argv)
-    if args.dump_refs:
-        dump_refs(ensure_h5(Path(args.h5)), args.dump_refs)
-        return 0
-
-    systems = run_systems(load_refs(args), args)
+    systems = run_systems(load_paper(ensure_h5(Path(args.h5))), args)
     # written before the exit code is decided, so a shard that lost a system
     # still hands the rest over to the aggregator
     if args.out_json:

--- a/src/mbd_c_api.F90
+++ b/src/mbd_c_api.F90
@@ -28,7 +28,8 @@ public :: cmbd_init_geom, cmbd_destroy_geom, cmbd_init_damping, &
     cmbd_destroy_damping, cmbd_get_exception, cmbd_update_coords, cmbd_update_lattice, &
     cmbd_get_results, cmbd_destroy_result, cmbd_print_timing
 public :: cmbd_ts_energy, cmbd_mbd_energy, cmbd_mbd_scs_energy, &
-    cmbd_dipole_matrix, cmbd_coulomb_energy, cmbd_dipole_energy
+    cmbd_dipole_matrix, cmbd_coulomb_energy, cmbd_dipole_energy, &
+    cmbd_nonint_density, cmbd_int_density
 
 #ifdef WITH_MPI
 logical(c_bool), bind(c) :: cmbd_with_mpi = .true.


### PR DESCRIPTION
Stacked on #146. The `prefetch` job existed only to spare each shard the 185 MB figshare download and the `pandas`/`tables` install. That saving is not worth the extra job, the data artifact and a second input format in the runner.

- `devtools/pyscf_s66x8_figshare_check.py`: `--refs`/`--dump-refs`, `dump_refs()` and `load_refs()` are gone; `load_paper()` returns the dict the run loop consumes, `--vdwsets` is required again.
- `.github/workflows/benchmark.yaml`: no `prefetch` job. Each shard restores the h5 from the actions cache (or downloads and sha256-checks it), clones the pinned vdwsets commit, and installs `pandas tables` next to pyMBD.

Result JSON, aggregator and baseline are untouched. `ruff check`/`ruff format --check` clean.

## Also: two masked CI breakages, found via codecov

The first push of this PR tripped `codecov/project` (84.8 % → 74.1 %) although the diff touches only devtools. Digging into it turned up two failures on the base branch that the `Test pyMBD` step has been hiding, because it pipes `make test` through `tee` without `pipefail` and only greps for "failed". Both are fixed here in separate commits; feel free to cherry-pick them onto master ahead of #146.

**Export the density bindings from the C API module.** Since the September cache refresh the conda legs resolve gfortran 16.2, which gives private bind(C) module procedures hidden visibility. `mbd_c_api` is `private` by default and `cmbd_nonint_density`/`cmbd_int_density` were never in its `public ::` list, so they dropped out of `libmbd.so` and pyMBD's cffi extension, which references every function in `mbd.h`, failed to load (`undefined symbol: cmbd_nonint_density`). The Python suite then did not run on any conda leg. Master's Aug 31 scheduled run already shows the same `ImportError`, behind a green check. Reproduced in a local conda-forge env with gfortran 16.2.0: before the fix `libmbd.so` exports 16 `cmbd_` symbols and the import fails, after it 18 and the full suite passes. CHANGELOG entry added.

**Stop masking Python test failures in CI.** `set -o pipefail` on both `Test pyMBD` steps. That alone would have turned the Intel legs red, because they have never run the Python suite: their venv lived inside the workspace (`${{ github.workspace }}/env`), an untracked directory that poetry-dynamic-versioning counts as dirty, so pyMBD got a `.dirty` suffix, its git suffix stopped matching libMBD's, and the import-time check in `pymbd/fortran.py` asserted (visible in every Intel log back to June). The venv now lives in `$HOME` like on the other legs. Verified locally with ifx 2025.0.4 + MKL: venv in the workspace reproduces the `.dirty` version, venv outside it passes the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VF7BWCGSqUPkbfi9ERUMMo